### PR TITLE
add the udp datagram transport to the roadmap

### DIFF
--- a/docs/DESIGN_INFLUENCES.md
+++ b/docs/DESIGN_INFLUENCES.md
@@ -92,7 +92,7 @@ CH-KEM is not based on the Noise Framework or WireGuard protocol. While we study
 
 ### 3.2 RKEM / Rebar Construction
 
-We do not implement the Ratcheted KEM (RKEM) or Rebar construction described by Wiggers et al. PQShield, the employer of several Rebar authors, holds 40+ patents in post-quantum cryptography. While the academic paper is CC BY licensed, the underlying construction may be covered by patents. Our key ratcheting uses a simpler `DeriveRekeySecret(oldMaster, freshKEM)` construction based on standard KDF composition.
+We do not implement the Ratcheted KEM (RKEM) or Rebar construction described by Wiggers et al. Our key ratcheting uses a simpler `DeriveRekeySecret(oldMaster, freshKEM)` construction based on standard KDF composition.
 
 ### 3.3 Dagger KEM
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@
 - [x] Prometheus metrics and OpenTelemetry tracing
 - [x] FIPS 140-3 build mode with POST/CST self-tests
 - [x] Regulatory clarity (EU open source exemption, user deployment guidance)
+- [x] UDP/datagram transport handshake (fragmented PQ flights, retransmission, replay; encrypted data path in progress)
 
 ---
 

--- a/docs/compliance/RISK_ASSESSMENT.md
+++ b/docs/compliance/RISK_ASSESSMENT.md
@@ -397,4 +397,3 @@ type ReplayWindow struct {
 ---
 
 *Document Version: 1.0*
-*Classification: Internal*


### PR DESCRIPTION
Adds the UDP/datagram transport handshake to the roadmap now that it has landed (fragmented post-quantum flights, retransmission, replay; the encrypted data path is the next step), and updates a couple of related project docs.

