### PR TITLE
add load-gated stateless cookie anti-amplification for the datagram handshake

### DIFF
--- a/cmd/quantum-tunnel/bench.go
+++ b/cmd/quantum-tunnel/bench.go
@@ -123,7 +123,11 @@ func benchDatagramHandshakes(count int) {
 		fmt.Fprintf(os.Stderr, "Error: Failed to open responder socket: %v\n", err)
 		os.Exit(1)
 	}
-	responder := tunnel.NewDatagramEndpoint(responderConn)
+	responder, err := tunnel.NewDatagramEndpoint(responderConn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to create responder endpoint: %v\n", err)
+		os.Exit(1)
+	}
 	go responder.Serve()
 	defer func() { _ = responder.Close() }()
 
@@ -132,7 +136,11 @@ func benchDatagramHandshakes(count int) {
 		fmt.Fprintf(os.Stderr, "Error: Failed to open initiator socket: %v\n", err)
 		os.Exit(1)
 	}
-	initiator := tunnel.NewDatagramEndpoint(initiatorConn)
+	initiator, err := tunnel.NewDatagramEndpoint(initiatorConn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Failed to create initiator endpoint: %v\n", err)
+		os.Exit(1)
+	}
 	go initiator.Serve()
 	defer func() { _ = initiator.Close() }()
 

--- a/docs/datagram-dos.md
+++ b/docs/datagram-dos.md
@@ -1,0 +1,95 @@
+# Datagram transport: DoS threat model and anti-amplification
+
+This document covers the denial-of-service posture of the UDP/datagram transport
+and the stateless return-routability cookie that hardens its handshake. For the
+transport's wire format and handshake mechanics see
+[datagram-transport.md](datagram-transport.md).
+
+## Threat
+
+UDP source addresses are trivially spoofable, so a connectionless handshake has
+two classic abuse surfaces:
+
+- **State / CPU exhaustion.** An attacker floods handshake initiations from forged
+  sources. For each, a naive server allocates per-source reassembly buffers and
+  runs an expensive CH-KEM `Encapsulate`, exhausting memory or CPU without ever
+  completing a handshake.
+- **Reflection / amplification.** Because the server's `ServerHello` (~1.6 KB) is
+  larger than the triggering `ClientHello` fragment, a spoofed initiation makes the
+  server reflect amplified traffic at a victim whose address the attacker forged.
+
+The dominant exhaustion vector specifically is **reassembler occupancy**: the PQ
+`ClientHello` spans multiple datagrams, so an attacker can send only the leading
+fragment from each of many forged sources, filling the reassembler's global
+source table and never completing a message. Any defense keyed on *completed*
+handshakes (e.g. a half-open responder count) would never see this attack.
+
+## Defense: load-gated stateless cookie
+
+Before committing reassembly buffers or CH-KEM work for a source it does not
+already track, the endpoint can demand a **return-routability cookie** the source
+must echo. An off-path spoofer never receives the cookie (it goes to the forged
+address), so it cannot proceed. This is the QUIC `RETRY` posture.
+
+- **Stateless.** A cookie is `HMAC-SHA256(secret, addr || issue_time)` plus the
+  8-byte issue time; the server keeps no per-source state to issue or verify one.
+  The 32-byte secret is drawn from the CSPRNG per endpoint at startup. (See
+  `pkg/tunnel/dgram_cookie.go`.)
+- **Load-gated.** The gate is inactive under normal load, so honest handshakes add
+  zero round trips. It engages only when the endpoint is under pressure, defined as
+  either the in-progress reassembly source count **or** the global half-open count
+  crossing `DatagramCookiePressureHighWater` (half of the hard half-open cap). The
+  two signals are complementary: reassembler occupancy catches the
+  partial-fragment flood, the half-open count catches a completed-ClientHello /
+  CH-KEM flood.
+- **Pre-reassembly.** The gate sits in `routeDatagram` *before* `reasm.Add`, so a
+  rejected frame allocates no reassembly buffer and triggers no CH-KEM. Verifying a
+  cookie (one HMAC over ~40 bytes) is far cheaper than the buffer it prevents.
+- **Keyed on "known source", not `RecvIndex`.** The gate lets through only sources
+  already tracked (an established session by connection index, or an in-progress
+  responder by source address). Gating on tracked-ness rather than on
+  `RecvIndex == 0` is what stops an attacker from dodging the gate by stamping a
+  random nonzero `RecvIndex` on a spoofed bootstrap `ClientHello`.
+
+## Anti-amplification
+
+The `RETRY` carrying a cookie is `DatagramHeaderSize + cookieSize` = 14 + 40 = 54
+bytes. The server sends it only:
+
+- in response to a `ClientHello` first fragment (`FragOffset == 0`), and
+- only when the `RETRY` is no larger than the triggering datagram
+  (`len(request) >= len(retry)`).
+
+The size check makes `RETRY` strictly de-amplifying even against a deliberately
+tiny runt fragment: the response is never larger than the request, so `RETRY` can
+never itself be used as a reflector. A valid cookie replayed from a spoofed
+address also buys nothing: the resulting `ServerHello` goes to the bound address,
+which the off-path attacker cannot receive.
+
+## Tradeoffs and residual gaps
+
+- **Endpoint-wide pressure.** A flood pushes the whole endpoint into
+  cookie-required mode, so honest clients pay one extra round trip for the duration
+  of the flood. Per-source pressure scoping is future work.
+- **Cookie lifetime.** Cookies are valid for 10 seconds (`cookieLifetime`),
+  bounding the replay window for a captured cookie from the same address.
+- **Secret rotation is restart-only.** A process restart rotates the cookie secret
+  and invalidates outstanding cookies, costing one extra `RETRY` round trip on the
+  next attempt. Periodic in-process rotation (with a two-generation accept window
+  so a rotation does not invalidate in-flight cookies) is future work.
+- **Roaming authentication** (binding a moved peer address to an
+  AEAD-authenticated, replay-fresh frame) is tracked separately and not part of
+  this hardening.
+
+## Tests
+
+- `pkg/tunnel/dgram_cookie_test.go` - cookie issue/verify, expiry, address
+  binding, tamper rejection, per-endpoint secret isolation.
+- `pkg/tunnel/dgram_cookie_gate_test.go` - `knownSource`, global half-open
+  accounting, pressure threshold, spoofed-source flood (zero sessions, zero
+  reassembly sources, only de-amplifying RETRYs), runt-fragment no-RETRY floor,
+  valid-cookie admission, RETRY delivery to the initiator.
+- `pkg/tunnel/dgram_handshake_e2e_test.go` - full handshake completing through the
+  cookie gate under forced pressure.
+- `test/fuzz/datagram_fuzz_test.go` - `FuzzParseDatagramRetry`,
+  `FuzzParseDatagramHandshake`.

--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -22,7 +22,8 @@ is updated as pieces land.
 | Data path (DatagramConn Send/Recv/Close) + idle reaper | `pkg/tunnel/dgram_conn.go`, `datagram.go` | implemented |
 | Reliable rekey transport (fragmented sub-handshake) | `pkg/tunnel/dgram_rekey.go` | implemented |
 | Zero-alloc / batched I/O | - | future |
-| Stateless cookie / anti-amplification / roaming | - | future |
+| Stateless cookie / anti-amplification | done |
+| Authenticated roaming | future |
 
 ## Wire format
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -220,6 +220,15 @@ const (
 	// sources.
 	DatagramMaxHalfOpenTotal = 1024
 
+	// DatagramCookiePressureHighWater is the load at which the datagram endpoint
+	// starts demanding a stateless return-routability cookie from new sources
+	// before committing handshake state (the QUIC-style anti-DoS posture). It is
+	// compared against both the in-progress reassembly source count and the global
+	// half-open count; either crossing it flips the endpoint into cookie-required
+	// mode. Set to half of DatagramMaxHalfOpenTotal so cookies engage well before
+	// the hard caps are reached, leaving headroom for the verified path.
+	DatagramCookiePressureHighWater = DatagramMaxHalfOpenTotal / 2
+
 	// DatagramReplayWindowBits is the width of the datagram anti-replay window.
 	DatagramReplayWindowBits = 1024
 

--- a/pkg/protocol/datagram_codec.go
+++ b/pkg/protocol/datagram_codec.go
@@ -234,3 +234,28 @@ func ParseDatagramHandshake(data []byte) (DatagramHandshakeHeader, []byte, error
 	}
 	return h, fragment, nil
 }
+
+// EncodeDatagramRetry builds a RETRY frame: the common header carrying the
+// client's connection index (so the client demuxes it like any other frame),
+// followed by an opaque cookie the client must echo in its next ClientHello.
+// Epoch and Seq are unused (zero); RETRY is sent before any key or replay state
+// exists for the peer.
+func EncodeDatagramRetry(recvIndex uint32, cookie []byte) []byte {
+	buf := make([]byte, DatagramHeaderSize+len(cookie))
+	putDatagramHeader(buf, DatagramHeader{Type: DatagramFrameRetry, RecvIndex: recvIndex})
+	copy(buf[DatagramHeaderSize:], cookie)
+	return buf
+}
+
+// ParseDatagramRetry parses a RETRY frame and returns the client connection
+// index it targets and the opaque cookie. The returned cookie aliases data.
+func ParseDatagramRetry(data []byte) (recvIndex uint32, cookie []byte, err error) {
+	h, body, err := ParseDatagramHeader(data)
+	if err != nil {
+		return 0, nil, err
+	}
+	if h.Type != DatagramFrameRetry {
+		return 0, nil, qerrors.ErrInvalidMessage
+	}
+	return h.RecvIndex, body, nil
+}

--- a/pkg/protocol/datagram_retry_test.go
+++ b/pkg/protocol/datagram_retry_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRetryRoundTrip(t *testing.T) {
+	cookie := []byte("opaque-stateless-cookie-bytes")
+	frame := EncodeDatagramRetry(0xA1B2C3D4, cookie)
+
+	ft, err := PeekDatagramType(frame)
+	if err != nil {
+		t.Fatalf("PeekDatagramType: %v", err)
+	}
+	if ft != DatagramFrameRetry {
+		t.Fatalf("frame type = %#x, want %#x", ft, DatagramFrameRetry)
+	}
+
+	idx, got, err := ParseDatagramRetry(frame)
+	if err != nil {
+		t.Fatalf("ParseDatagramRetry: %v", err)
+	}
+	if idx != 0xA1B2C3D4 {
+		t.Fatalf("recvIndex = %#x, want 0xA1B2C3D4", idx)
+	}
+	if !bytes.Equal(got, cookie) {
+		t.Fatalf("cookie = %q, want %q", got, cookie)
+	}
+}
+
+func TestRetryRejectsWrongType(t *testing.T) {
+	// A DATA frame must not parse as RETRY.
+	data := EncodeDatagramData(DatagramHeader{RecvIndex: 1, Seq: 1}, []byte("ct"))
+	if _, _, err := ParseDatagramRetry(data); err == nil {
+		t.Fatal("ParseDatagramRetry accepted a non-RETRY frame")
+	}
+}
+
+func TestRetryRejectsShort(t *testing.T) {
+	if _, _, err := ParseDatagramRetry([]byte{0x04, 0x00}); err == nil {
+		t.Fatal("ParseDatagramRetry accepted a truncated header")
+	}
+}
+
+func TestRetryEmptyCookie(t *testing.T) {
+	frame := EncodeDatagramRetry(7, nil)
+	idx, cookie, err := ParseDatagramRetry(frame)
+	if err != nil {
+		t.Fatalf("ParseDatagramRetry: %v", err)
+	}
+	if idx != 7 || len(cookie) != 0 {
+		t.Fatalf("got idx=%d cookieLen=%d, want idx=7 cookieLen=0", idx, len(cookie))
+	}
+}

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -67,6 +67,11 @@ type datagramSession struct {
 	rekeyRespFrom   uint8
 	rekeyRespValid  bool
 	rekeyRespFrames [][]byte
+
+	// retryCh delivers a server anti-DoS cookie (from a RETRY frame) to an
+	// initiator handshake goroutine so it can re-send its ClientHello carrying the
+	// cookie. Only the initiator (DialDatagram) creates it.
+	retryCh chan []byte
 }
 
 // beginRekey claims the single initiator rekey slot, returning false if one is
@@ -99,10 +104,11 @@ func (ds *datagramSession) teardown(r *connRegistry) {
 // per-source caps are the active pre-auth memory bounds. A future stateless
 // cookie/retry exchange removes the spoofed-source vector entirely.
 type connRegistry struct {
-	mu       sync.Mutex
-	byIndex  map[uint32]*datagramSession
-	bySource map[string]*datagramSession // in-progress responder handshakes, keyed by source
-	halfOpen map[string]int              // source identity -> count of un-established sessions
+	mu            sync.Mutex
+	byIndex       map[uint32]*datagramSession
+	bySource      map[string]*datagramSession // in-progress responder handshakes, keyed by source
+	halfOpen      map[string]int              // source identity -> count of un-established sessions
+	halfOpenTotal int                         // sum of halfOpen across all sources (cookie-pressure signal)
 }
 
 func newConnRegistry() *connRegistry {
@@ -193,6 +199,7 @@ func (r *connRegistry) tryAddHalfOpen(source string) bool {
 		return false
 	}
 	r.halfOpen[source]++
+	r.halfOpenTotal++
 	return true
 }
 
@@ -201,11 +208,41 @@ func (r *connRegistry) tryAddHalfOpen(source string) bool {
 func (r *connRegistry) releaseHalfOpen(source string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if n := r.halfOpen[source]; n > 1 {
+	n := r.halfOpen[source]
+	if n == 0 {
+		return
+	}
+	if n > 1 {
 		r.halfOpen[source] = n - 1
 	} else {
 		delete(r.halfOpen, source)
 	}
+	r.halfOpenTotal--
+}
+
+// halfOpenLoad returns the global half-open count, one of the endpoint's
+// cookie-pressure signals.
+func (r *connRegistry) halfOpenLoad() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.halfOpenTotal
+}
+
+// knownSource reports whether an incoming handshake frame belongs to a source we
+// already track: an established session under index, or an in-progress responder
+// for src. The cookie gate lets known sources through unchallenged; gating on
+// "known" (not on RecvIndex == 0) is what stops an attacker from dodging the gate
+// by stamping a random nonzero RecvIndex on a spoofed bootstrap ClientHello.
+func (r *connRegistry) knownSource(index uint32, src string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if index != 0 {
+		if _, ok := r.byIndex[index]; ok {
+			return true
+		}
+	}
+	_, ok := r.bySource[src]
+	return ok
 }
 
 // addSource registers an in-progress responder handshake under its source so a
@@ -240,6 +277,14 @@ type DatagramEndpoint struct {
 	reasm    *Reassembler
 	acceptCh chan *datagramSession
 
+	// cookie mints and verifies stateless return-routability cookies for the
+	// anti-DoS gate (see dgram_cookie.go).
+	cookie *cookieSigner
+	// cookiePressureHighWater is the load at which the endpoint demands a cookie
+	// from new sources; defaulted from constants, lowered (in-package) for tests
+	// so pressure can be forced without thousands of real sources.
+	cookiePressureHighWater int
+
 	// rtoInitial/rtoMax bound handshake retransmission backoff; defaulted from
 	// constants, overridable (in-package) for fast tests.
 	rtoInitial time.Duration
@@ -255,18 +300,36 @@ type DatagramEndpoint struct {
 
 // NewDatagramEndpoint wraps a PacketConn (a *net.UDPConn in production, or a
 // fault-injecting conn in tests). It does not start the receive loop; callers
-// start it explicitly so tests can drive routing deterministically.
-func NewDatagramEndpoint(conn net.PacketConn) *DatagramEndpoint {
-	return &DatagramEndpoint{
-		conn:        conn,
-		registry:    newConnRegistry(),
-		reasm:       NewReassembler(0, 0, 0),
-		acceptCh:    make(chan *datagramSession, 16),
-		rtoInitial:  time.Duration(constants.DatagramHandshakeInitialTimeoutMillis) * time.Millisecond,
-		rtoMax:      time.Duration(constants.DatagramHandshakeMaxTimeoutMillis) * time.Millisecond,
-		idleTimeout: time.Duration(constants.DatagramIdleTimeoutSeconds) * time.Second,
-		done:        make(chan struct{}),
+// start it explicitly so tests can drive routing deterministically. It returns an
+// error only if the per-endpoint cookie secret cannot be drawn from the CSPRNG.
+func NewDatagramEndpoint(conn net.PacketConn) (*DatagramEndpoint, error) {
+	cookie, err := newCookieSigner(nil)
+	if err != nil {
+		return nil, err
 	}
+	return &DatagramEndpoint{
+		conn:                    conn,
+		registry:                newConnRegistry(),
+		reasm:                   NewReassembler(0, 0, 0),
+		acceptCh:                make(chan *datagramSession, 16),
+		cookie:                  cookie,
+		cookiePressureHighWater: constants.DatagramCookiePressureHighWater,
+		rtoInitial:              time.Duration(constants.DatagramHandshakeInitialTimeoutMillis) * time.Millisecond,
+		rtoMax:                  time.Duration(constants.DatagramHandshakeMaxTimeoutMillis) * time.Millisecond,
+		idleTimeout:             time.Duration(constants.DatagramIdleTimeoutSeconds) * time.Second,
+		done:                    make(chan struct{}),
+	}, nil
+}
+
+// underCookiePressure reports whether the endpoint should demand a
+// return-routability cookie from new sources. Either the in-progress reassembly
+// source count or the global half-open count crossing the high-water mark trips
+// it: reassembler occupancy catches a partial-fragment flood (nothing completes,
+// so the half-open count stays at zero), while the half-open count catches a
+// completed-ClientHello / CH-KEM flood.
+func (e *DatagramEndpoint) underCookiePressure() bool {
+	return e.reasm.sourceCount() >= e.cookiePressureHighWater ||
+		e.registry.halfOpenLoad() >= e.cookiePressureHighWater
 }
 
 // Close shuts the endpoint down and closes the underlying PacketConn. It is
@@ -342,6 +405,9 @@ func (e *DatagramEndpoint) routeDatagram(src net.Addr, data []byte) error {
 		if perr != nil {
 			return perr
 		}
+		if e.cookieGateRejects(src, h, data) {
+			return nil // dropped before any reassembly/CH-KEM state is committed
+		}
 		msg, complete, aerr := e.reasm.Add(src.String(), h, fragment)
 		if aerr != nil {
 			return aerr
@@ -409,7 +475,47 @@ func (e *DatagramEndpoint) routeDatagram(src net.Addr, data []byte) error {
 		ds.session.Close()
 		ds.teardown(e.registry)
 		return nil
+	case protocol.DatagramFrameRetry:
+		// A server's anti-DoS RETRY: hand the cookie to the initiator handshake
+		// named by RecvIndex so it can re-send its ClientHello carrying the cookie.
+		recvIndex, cookie, rerr := protocol.ParseDatagramRetry(data)
+		if rerr != nil {
+			return rerr
+		}
+		ds := e.registry.lookup(recvIndex)
+		if ds == nil || ds.retryCh == nil {
+			return nil // unknown index or not an initiator handshake: drop
+		}
+		select {
+		case ds.retryCh <- append([]byte(nil), cookie...):
+		default: // a RETRY is already queued: drop (the initiator only needs one)
+		}
+		return nil
 	default:
-		return nil // unknown or reserved frame type (e.g. RETRY, not yet handled): drop
+		return nil // unknown frame type: drop
 	}
+}
+
+// cookieGateRejects implements the stateless return-routability gate. Under load,
+// a handshake frame from a source we do not already track must echo a valid cookie
+// (return-routability proof) or it is dropped before committing any reassembly or
+// CH-KEM state. It answers a plausible bootstrap ClientHello first fragment with a
+// RETRY carrying a fresh cookie, but only when that RETRY is no larger than the
+// triggering datagram, so RETRY can never be an amplifier. It returns true when
+// the caller must drop the frame.
+func (e *DatagramEndpoint) cookieGateRejects(src net.Addr, h protocol.DatagramHandshakeHeader, data []byte) bool {
+	if !e.underCookiePressure() {
+		return false
+	}
+	if e.registry.knownSource(h.RecvIndex, src.String()) {
+		return false
+	}
+	if e.cookie.verify(src, h.Cookie) {
+		return false
+	}
+	retry := protocol.EncodeDatagramRetry(h.SenderIndex, e.cookie.issue(src))
+	if h.MsgType == protocol.MessageTypeClientHello && h.FragOffset == 0 && len(data) >= len(retry) {
+		_, _ = e.conn.WriteTo(retry, src)
+	}
+	return true
 }

--- a/pkg/tunnel/datagram_test.go
+++ b/pkg/tunnel/datagram_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/sara-star-quant/quantum-go/pkg/protocol"
 )
 
+// mustEndpoint builds a DatagramEndpoint for tests, failing on the CSPRNG-only
+// construction error so call sites stay terse.
+func mustEndpoint(t *testing.T, conn net.PacketConn) *DatagramEndpoint {
+	t.Helper()
+	ep, err := NewDatagramEndpoint(conn)
+	if err != nil {
+		t.Fatalf("NewDatagramEndpoint: %v", err)
+	}
+	return ep
+}
+
 func TestConnRegistryAddAssignsUniqueNonZeroIndices(t *testing.T) {
 	r := newConnRegistry()
 	const n = 1000
@@ -89,7 +100,7 @@ func TestConnRegistryHalfOpenCap(t *testing.T) {
 }
 
 func TestRouteDatagram(t *testing.T) {
-	e := NewDatagramEndpoint(nil) // routeDatagram does not touch the conn
+	e := mustEndpoint(t, nil) // routeDatagram does not touch the conn
 	src := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 51820}
 
 	// Too-short datagram: the type peek rejects it.

--- a/pkg/tunnel/dgram_conn_test.go
+++ b/pkg/tunnel/dgram_conn_test.go
@@ -18,8 +18,8 @@ import (
 func dgramPair(t *testing.T, seed uint64, drop, dup, reorder float64) (client, server *DatagramConn, epA, epB *DatagramEndpoint) {
 	t.Helper()
 	connA, connB := memPipe(seed, drop, dup, reorder)
-	epA = NewDatagramEndpoint(connA)
-	epB = NewDatagramEndpoint(connB)
+	epA = mustEndpoint(t, connA)
+	epB = mustEndpoint(t, connB)
 	for _, ep := range []*DatagramEndpoint{epA, epB} {
 		ep.rtoInitial = 2 * time.Millisecond
 		ep.rtoMax = 20 * time.Millisecond
@@ -236,7 +236,7 @@ func TestDatagramCloseAuth(t *testing.T) {
 // established session with stale activity is torn down within a few tick periods.
 func TestDatagramIdleReap(t *testing.T) {
 	connA, _ := memPipe(6, 0, 0, 0)
-	ep := NewDatagramEndpoint(connA)
+	ep := mustEndpoint(t, connA)
 	ep.idleTimeout = 40 * time.Millisecond
 	defer func() { _ = ep.Close() }()
 

--- a/pkg/tunnel/dgram_cookie.go
+++ b/pkg/tunnel/dgram_cookie.go
@@ -1,0 +1,85 @@
+// Package tunnel - dgram_cookie.go is the stateless return-routability cookie for
+// the datagram handshake. Before the server commits per-session state or runs
+// CH-KEM for an unverified source, it can demand that the source echo a cookie
+// that the server alone could have minted for that exact address. An off-path
+// attacker spoofing a victim's address never receives the RETRY carrying the
+// cookie, so it cannot complete the round trip - this is what closes the
+// residual spoofed-source state/CPU-exhaustion gap noted in datagram.go.
+//
+// The cookie holds no server-side state: it is an HMAC over the source address
+// and an issue timestamp, keyed by a per-endpoint secret minted at startup. A
+// process restart rotates the secret and invalidates outstanding cookies, which
+// only costs an extra RETRY round trip on the next attempt.
+package tunnel
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"net"
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/pkg/crypto"
+)
+
+const (
+	cookieSecretSize    = 32
+	cookieTimestampSize = 8
+	cookieMACSize       = sha256.Size
+	// cookieSize is the on-the-wire cookie length: an 8-byte issue timestamp
+	// followed by its address-bound MAC.
+	cookieSize = cookieTimestampSize + cookieMACSize
+	// cookieLifetime bounds how long an issued cookie stays valid, limiting the
+	// window in which a captured cookie can be replayed from the same address.
+	cookieLifetime = 10 * time.Second
+)
+
+// cookieSigner issues and verifies stateless return-routability cookies.
+type cookieSigner struct {
+	secret [cookieSecretSize]byte
+	now    func() time.Time
+}
+
+// newCookieSigner mints a signer with a random per-endpoint secret.
+func newCookieSigner(now func() time.Time) (*cookieSigner, error) {
+	if now == nil {
+		now = time.Now
+	}
+	cs := &cookieSigner{now: now}
+	if err := crypto.SecureRandom(cs.secret[:]); err != nil {
+		return nil, err
+	}
+	return cs, nil
+}
+
+// issue returns a fresh cookie bound to addr at the current time.
+func (cs *cookieSigner) issue(addr net.Addr) []byte {
+	cookie := make([]byte, cookieSize)
+	binary.BigEndian.PutUint64(cookie[:cookieTimestampSize], uint64(cs.now().UnixNano()))
+	copy(cookie[cookieTimestampSize:], cs.mac(addr, cookie[:cookieTimestampSize]))
+	return cookie
+}
+
+// verify reports whether cookie is a valid, unexpired cookie for addr. It is
+// constant-time in the MAC comparison so a forged cookie leaks no timing signal.
+func (cs *cookieSigner) verify(addr net.Addr, cookie []byte) bool {
+	if len(cookie) != cookieSize {
+		return false
+	}
+	if !hmac.Equal(cookie[cookieTimestampSize:], cs.mac(addr, cookie[:cookieTimestampSize])) {
+		return false
+	}
+	issued := time.Unix(0, int64(binary.BigEndian.Uint64(cookie[:cookieTimestampSize])))
+	age := cs.now().Sub(issued)
+	return age >= 0 && age <= cookieLifetime
+}
+
+// mac computes the address-bound MAC over the issue timestamp. Binding the
+// stringified address is what ties a cookie to one source: a cookie minted for
+// one peer fails verify for any other.
+func (cs *cookieSigner) mac(addr net.Addr, tsBytes []byte) []byte {
+	h := hmac.New(sha256.New, cs.secret[:])
+	_, _ = h.Write([]byte(addr.String()))
+	_, _ = h.Write(tsBytes)
+	return h.Sum(nil)
+}

--- a/pkg/tunnel/dgram_cookie_gate_test.go
+++ b/pkg/tunnel/dgram_cookie_gate_test.go
@@ -1,0 +1,243 @@
+package tunnel
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// captureConn is a net.PacketConn that records every WriteTo and never delivers a
+// read. Tests drive routeDatagram directly (no Serve loop), so ReadFrom is unused.
+type captureConn struct {
+	mu      sync.Mutex
+	written [][]byte
+}
+
+func (c *captureConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, net.ErrClosed }
+func (c *captureConn) WriteTo(p []byte, _ net.Addr) (int, error) {
+	c.mu.Lock()
+	c.written = append(c.written, append([]byte(nil), p...))
+	c.mu.Unlock()
+	return len(p), nil
+}
+func (c *captureConn) Close() error                     { return nil }
+func (c *captureConn) LocalAddr() net.Addr              { return memAddr{name: "cap"} }
+func (c *captureConn) SetDeadline(time.Time) error      { return nil }
+func (c *captureConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *captureConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *captureConn) writes() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([][]byte, len(c.written))
+	copy(out, c.written)
+	return out
+}
+
+// clientHelloFrame builds a single bootstrap ClientHello handshake frame with a
+// fragment of fragLen bytes and the given declared total length and cookie.
+func clientHelloFrame(t *testing.T, senderIndex uint32, recvIndex uint32, fragLen, total int, cookie []byte) []byte {
+	t.Helper()
+	frame, err := protocol.EncodeDatagramHandshake(protocol.DatagramHandshakeHeader{
+		DatagramHeader: protocol.DatagramHeader{RecvIndex: recvIndex},
+		SenderIndex:    senderIndex,
+		MsgType:        protocol.MessageTypeClientHello,
+		FragOffset:     0,
+		FragLength:     uint16(fragLen),
+		TotalLength:    uint16(total),
+		Cookie:         cookie,
+	}, make([]byte, fragLen))
+	if err != nil {
+		t.Fatalf("EncodeDatagramHandshake: %v", err)
+	}
+	return frame
+}
+
+func TestKnownSource(t *testing.T) {
+	r := newConnRegistry()
+	const src = "203.0.113.7:5000"
+
+	if r.knownSource(0, src) {
+		t.Fatal("empty registry must not report any source as known")
+	}
+
+	// An established session is known by its index regardless of source.
+	ds := &datagramSession{}
+	idx, err := r.add(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.knownSource(idx, "anything:1") {
+		t.Fatal("established index must be known")
+	}
+	if r.knownSource(idx^0xffffffff, src) {
+		t.Fatal("a different index with an unknown source must not be known")
+	}
+
+	// An in-progress responder is known by its source even with RecvIndex 0.
+	r.addSource(src, &datagramSession{})
+	if !r.knownSource(0, src) {
+		t.Fatal("in-progress source must be known")
+	}
+}
+
+func TestHalfOpenGlobalAccounting(t *testing.T) {
+	r := newConnRegistry()
+	if r.halfOpenLoad() != 0 {
+		t.Fatalf("initial load = %d, want 0", r.halfOpenLoad())
+	}
+	r.tryAddHalfOpen("a:1")
+	r.tryAddHalfOpen("a:1")
+	r.tryAddHalfOpen("b:1")
+	if got := r.halfOpenLoad(); got != 3 {
+		t.Fatalf("load = %d, want 3", got)
+	}
+	r.releaseHalfOpen("a:1")
+	if got := r.halfOpenLoad(); got != 2 {
+		t.Fatalf("load after release = %d, want 2", got)
+	}
+	// A spurious release must not drive the global counter negative.
+	r.releaseHalfOpen("never-added:1")
+	if got := r.halfOpenLoad(); got != 2 {
+		t.Fatalf("load after spurious release = %d, want 2", got)
+	}
+}
+
+func TestUnderCookiePressure(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	e.cookiePressureHighWater = 2
+
+	if e.underCookiePressure() {
+		t.Fatal("idle endpoint must not be under pressure")
+	}
+	e.registry.tryAddHalfOpen("a:1")
+	e.registry.tryAddHalfOpen("b:1")
+	if !e.underCookiePressure() {
+		t.Fatal("half-open count at the high-water must trip pressure")
+	}
+}
+
+func TestCookieGateDropsSpoofedFlood(t *testing.T) {
+	cc := &captureConn{}
+	e := mustEndpoint(t, cc)
+	e.cookiePressureHighWater = 0 // always under pressure
+
+	// Many distinct spoofed sources, each a full first-fragment ClientHello with a
+	// forged nonzero RecvIndex (the bypass attempt) and no cookie.
+	for i := 0; i < 50; i++ {
+		src := &net.UDPAddr{IP: net.IPv4(198, 51, 100, byte(i)), Port: 1234}
+		frame := clientHelloFrame(t, uint32(i+1), uint32(0xdead0000+i), 1000, 1600, nil)
+		if err := e.routeDatagram(src, frame); err != nil {
+			t.Fatalf("routeDatagram: %v", err)
+		}
+	}
+
+	if got := e.registry.count(); got != 0 {
+		t.Fatalf("spoofed flood created %d sessions, want 0", got)
+	}
+	if got := e.reasm.sourceCount(); got != 0 {
+		t.Fatalf("spoofed flood allocated %d reassembly sources, want 0", got)
+	}
+	// Every emitted frame must be a (de-amplifying) RETRY, never a ServerHello.
+	writes := cc.writes()
+	if len(writes) == 0 {
+		t.Fatal("expected RETRY responses to the flood")
+	}
+	for _, w := range writes {
+		ft, err := protocol.PeekDatagramType(w)
+		if err != nil || ft != protocol.DatagramFrameRetry {
+			t.Fatalf("emitted non-RETRY frame type %v (err %v)", ft, err)
+		}
+		// The first ClientHello fragment was ~1026 B; the RETRY must be smaller.
+		if len(w) >= 1000 {
+			t.Fatalf("RETRY of %d bytes is not de-amplifying", len(w))
+		}
+	}
+}
+
+func TestCookieGateNoRetryOnRunt(t *testing.T) {
+	cc := &captureConn{}
+	e := mustEndpoint(t, cc)
+	e.cookiePressureHighWater = 0
+
+	// A runt first fragment smaller than a RETRY: dropped, but no RETRY (so it can
+	// never be used as an amplifier).
+	src := &net.UDPAddr{IP: net.IPv4(198, 51, 100, 1), Port: 1234}
+	runt := clientHelloFrame(t, 1, 0, 1, 1600, nil)
+	if len(runt) >= protocol.DatagramHeaderSize+cookieSize {
+		t.Fatalf("runt frame %d bytes is not actually a runt", len(runt))
+	}
+	if err := e.routeDatagram(src, runt); err != nil {
+		t.Fatalf("routeDatagram: %v", err)
+	}
+	if got := len(cc.writes()); got != 0 {
+		t.Fatalf("runt fragment elicited %d responses, want 0", got)
+	}
+	if e.reasm.sourceCount() != 0 {
+		t.Fatal("runt fragment allocated reassembly state")
+	}
+}
+
+func TestCookieGateAdmitsValidCookie(t *testing.T) {
+	cc := &captureConn{}
+	e := mustEndpoint(t, cc)
+	e.cookiePressureHighWater = 0
+
+	src := &net.UDPAddr{IP: net.IPv4(198, 51, 100, 1), Port: 1234}
+	cookie := e.cookie.issue(src)
+	frame := clientHelloFrame(t, 1, 0, 1000, 1600, cookie)
+	if err := e.routeDatagram(src, frame); err != nil {
+		t.Fatalf("routeDatagram: %v", err)
+	}
+	// A valid cookie lets the fragment through to reassembly (a partial message, so
+	// one reassembly source is now tracked) and emits no RETRY.
+	if got := e.reasm.sourceCount(); got != 1 {
+		t.Fatalf("valid-cookie fragment reassembly sources = %d, want 1", got)
+	}
+	for _, w := range cc.writes() {
+		if ft, _ := protocol.PeekDatagramType(w); ft == protocol.DatagramFrameRetry {
+			t.Fatal("a valid cookie must not elicit a RETRY")
+		}
+	}
+}
+
+func TestRouteRetryDeliversCookie(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	ds := &datagramSession{retryCh: make(chan []byte, 1)}
+	idx, err := e.registry.add(ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookie := []byte("a-server-cookie")
+	frame := protocol.EncodeDatagramRetry(idx, cookie)
+	if err := e.routeDatagram(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}, frame); err != nil {
+		t.Fatalf("routeDatagram: %v", err)
+	}
+	select {
+	case got := <-ds.retryCh:
+		if string(got) != string(cookie) {
+			t.Fatalf("delivered cookie = %q, want %q", got, cookie)
+		}
+	default:
+		t.Fatal("RETRY did not deliver a cookie to the initiator")
+	}
+
+	// A RETRY for an unknown index is dropped cleanly.
+	if err := e.routeDatagram(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1},
+		protocol.EncodeDatagramRetry(idx^0xffffffff, cookie)); err != nil {
+		t.Fatalf("RETRY for unknown index should drop, got %v", err)
+	}
+}
+
+// Guard: the pressure default is the configured constant.
+func TestCookiePressureDefault(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	if e.cookiePressureHighWater != constants.DatagramCookiePressureHighWater {
+		t.Fatalf("default high-water = %d, want %d",
+			e.cookiePressureHighWater, constants.DatagramCookiePressureHighWater)
+	}
+}

--- a/pkg/tunnel/dgram_cookie_test.go
+++ b/pkg/tunnel/dgram_cookie_test.go
@@ -1,0 +1,114 @@
+package tunnel
+
+import (
+	"testing"
+	"time"
+)
+
+// cookieAddr is a minimal net.Addr for cookie-binding tests.
+type cookieAddr string
+
+func (a cookieAddr) Network() string { return "udp" }
+func (a cookieAddr) String() string  { return string(a) }
+
+func TestCookieRoundTrip(t *testing.T) {
+	cs, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	cookie := cs.issue(addr)
+	if len(cookie) != cookieSize {
+		t.Fatalf("cookie size = %d, want %d", len(cookie), cookieSize)
+	}
+	if !cs.verify(addr, cookie) {
+		t.Fatal("freshly issued cookie failed verification")
+	}
+}
+
+func TestCookieRejectsWrongAddr(t *testing.T) {
+	cs, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	cookie := cs.issue(cookieAddr("203.0.113.7:5000"))
+	if cs.verify(cookieAddr("203.0.113.8:5000"), cookie) {
+		t.Fatal("cookie verified for a different address")
+	}
+}
+
+func TestCookieExpiry(t *testing.T) {
+	clk := time.Unix(1_700_000_000, 0)
+	cs, err := newCookieSigner(func() time.Time { return clk })
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	cookie := cs.issue(addr)
+
+	clk = clk.Add(cookieLifetime - time.Second)
+	if !cs.verify(addr, cookie) {
+		t.Fatal("cookie expired before its lifetime")
+	}
+	clk = clk.Add(2 * time.Second)
+	if cs.verify(addr, cookie) {
+		t.Fatal("cookie verified past its lifetime")
+	}
+}
+
+func TestCookieRejectsFutureTimestamp(t *testing.T) {
+	clk := time.Unix(1_700_000_000, 0)
+	cs, err := newCookieSigner(func() time.Time { return clk })
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	cookie := cs.issue(addr)
+	// Rewind the clock so the cookie appears issued in the future.
+	clk = clk.Add(-time.Minute)
+	if cs.verify(addr, cookie) {
+		t.Fatal("cookie with a future timestamp verified")
+	}
+}
+
+func TestCookieRejectsTamper(t *testing.T) {
+	cs, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	cookie := cs.issue(addr)
+	cookie[len(cookie)-1] ^= 0xff
+	if cs.verify(addr, cookie) {
+		t.Fatal("tampered cookie verified")
+	}
+}
+
+func TestCookieRejectsBadLength(t *testing.T) {
+	cs, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	if cs.verify(addr, nil) {
+		t.Fatal("nil cookie verified")
+	}
+	if cs.verify(addr, cs.issue(addr)[:cookieSize-1]) {
+		t.Fatal("short cookie verified")
+	}
+}
+
+func TestCookieDistinctSecrets(t *testing.T) {
+	a, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	b, err := newCookieSigner(nil)
+	if err != nil {
+		t.Fatalf("newCookieSigner: %v", err)
+	}
+	addr := cookieAddr("203.0.113.7:5000")
+	if b.verify(addr, a.issue(addr)) {
+		t.Fatal("cookie issued by one signer verified by another")
+	}
+}

--- a/pkg/tunnel/dgram_handshake_driver.go
+++ b/pkg/tunnel/dgram_handshake_driver.go
@@ -206,3 +206,14 @@ func (d *dgramDriver) done() bool {
 
 // session returns the underlying session (established once established() is true).
 func (d *dgramDriver) session() *Session { return d.fsm.hs.session }
+
+// cachedFlight returns the FSM's last outbound message for an on-demand resend
+// (the initiator replaying its ClientHello after a RETRY), or nil if the driver
+// is terminal or has nothing cached. It does not touch the retransmit backoff or
+// ceiling, so a resend on a RETRY is independent of the loss-timer budget.
+func (d *dgramDriver) cachedFlight() []hsMessage {
+	if d.status != driverRunning || d.fsm.cached == nil {
+		return nil
+	}
+	return []hsMessage{*d.fsm.cached}
+}

--- a/pkg/tunnel/dgram_handshake_driver_test.go
+++ b/pkg/tunnel/dgram_handshake_driver_test.go
@@ -284,7 +284,7 @@ func TestDgramHandshakeDriverLingerCoversRetransmitWindow(t *testing.T) {
 // and neither the driver tests nor the e2e (which would just pass, slowly) would
 // catch it.
 func TestDatagramEndpointPropagatesRTO(t *testing.T) {
-	ep := NewDatagramEndpoint(nil)
+	ep := mustEndpoint(t, nil)
 	ep.rtoInitial = 7 * time.Millisecond
 	ep.rtoMax = 70 * time.Millisecond
 

--- a/pkg/tunnel/dgram_handshake_e2e_test.go
+++ b/pkg/tunnel/dgram_handshake_e2e_test.go
@@ -156,8 +156,8 @@ func TestDgramHandshakeE2E(t *testing.T) {
 func runE2E(t *testing.T, seed uint64, drop, dup, reorder float64) {
 	t.Helper()
 	connA, connB := memPipe(seed, drop, dup, reorder)
-	epA := NewDatagramEndpoint(connA)
-	epB := NewDatagramEndpoint(connB)
+	epA := mustEndpoint(t, connA)
+	epB := mustEndpoint(t, connB)
 	for _, ep := range []*DatagramEndpoint{epA, epB} {
 		ep.rtoInitial = 2 * time.Millisecond
 		ep.rtoMax = 20 * time.Millisecond
@@ -199,6 +199,60 @@ func runE2E(t *testing.T, seed uint64, drop, dup, reorder float64) {
 	if client == nil || server == nil {
 		t.Fatal("nil session(s) after handshake")
 	}
+	if client.State() != SessionStateEstablished || server.State() != SessionStateEstablished {
+		t.Fatalf("not established: client=%v server=%v", client.State(), server.State())
+	}
+	assertDataRoundTrip(t, client, server)
+	assertDataRoundTrip(t, server, client)
+}
+
+// TestDgramHandshakeCookieRoundTrip drives a full handshake with the responder
+// forced permanently under cookie pressure, so the initiator's first ClientHello
+// is answered with a RETRY. It asserts the initiator adopts the cookie, re-sends,
+// and the handshake then completes with working bidirectional data keys.
+func TestDgramHandshakeCookieRoundTrip(t *testing.T) {
+	connA, connB := memPipe(1, 0, 0, 0) // lossless: isolate the cookie round trip
+	epA := mustEndpoint(t, connA)
+	epB := mustEndpoint(t, connB)
+	epB.cookiePressureHighWater = 0 // responder always demands a cookie
+	for _, ep := range []*DatagramEndpoint{epA, epB} {
+		ep.rtoInitial = 2 * time.Millisecond
+		ep.rtoMax = 20 * time.Millisecond
+	}
+	go epA.Serve()
+	go epB.Serve()
+	defer func() { _ = epA.Close() }()
+	defer func() { _ = epB.Close() }()
+
+	type dialResult struct {
+		conn *DatagramConn
+		err  error
+	}
+	dialCh := make(chan dialResult, 1)
+	go func() {
+		c, err := DialDatagram(epA, connB.addr)
+		dialCh <- dialResult{c, err}
+	}()
+
+	var server *Session
+	select {
+	case ds := <-epB.acceptCh:
+		server = ds.session
+	case <-time.After(5 * time.Second):
+		t.Fatal("responder did not surface a session through the cookie gate")
+	}
+
+	var client *Session
+	select {
+	case r := <-dialCh:
+		if r.err != nil {
+			t.Fatalf("dial: %v", r.err)
+		}
+		client = r.conn.Session()
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not complete through the cookie gate")
+	}
+
 	if client.State() != SessionStateEstablished || server.State() != SessionStateEstablished {
 		t.Fatalf("not established: client=%v server=%v", client.State(), server.State())
 	}

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -118,6 +118,7 @@ func DialDatagram(ep *DatagramEndpoint, dst net.Addr) (*DatagramConn, error) {
 		recvCh:     make(chan []byte, dataInboxCap),
 		closed:     make(chan struct{}),
 		rekeyInbox: make(chan []byte, 4),
+		retryCh:    make(chan []byte, 1),
 	}
 	idx, err := ep.registry.add(ds)
 	if err != nil {
@@ -165,12 +166,21 @@ type handshakeLoop struct {
 	peerIndex  uint32
 	seq        uint64
 
+	// cookie is the server's anti-DoS cookie echoed on ClientHello resends, set
+	// from a RETRY. retriesHonored bounds how many RETRYs we act on, so a forged
+	// RETRY stream (the index is guessable) cannot drive unbounded resends.
+	cookie         []byte
+	retriesHonored int
+
 	// established, if set, is called once when the session is keyed (responders
 	// surface it on acceptCh). Initiators leave it nil and take the session from
 	// run's return value.
 	established func()
 	surfaced    bool
 }
+
+// maxHonoredRetries bounds RETRY-driven ClientHello resends per handshake.
+const maxHonoredRetries = 3
 
 // run drives the handshake to completion or failure. The initiator sends the
 // first ClientHello; both roles then loop on {inbound, retransmit timer, close},
@@ -196,6 +206,8 @@ func (l *handshakeLoop) run() (*Session, error) {
 				l.peerIndex = m.sender
 			}
 			l.send(l.driver.onInbound(m.typ, m.body))
+		case cookie := <-l.retryCh():
+			l.onRetry(cookie)
 		case <-timer.C:
 			l.send(l.driver.onTimeout())
 		case <-l.ep.done:
@@ -211,6 +223,34 @@ func (l *handshakeLoop) run() (*Session, error) {
 		return nil, errHandshakeFailed
 	}
 	return l.ds.session, nil
+}
+
+// retryCh returns the session's RETRY-cookie channel, or nil for a responder
+// (which has none). A nil channel makes the run-loop's RETRY select case block
+// forever, so only initiators ever react to a RETRY.
+func (l *handshakeLoop) retryCh() chan []byte {
+	if l.ds == nil {
+		return nil
+	}
+	return l.ds.retryCh
+}
+
+// onRetry reacts to a server anti-DoS RETRY: adopt the cookie and re-send the
+// cached ClientHello carrying it. It acts only while the cached flight is still
+// the ClientHello (a RETRY is meaningless once the handshake has advanced) and is
+// bounded by maxHonoredRetries, so a forged RETRY stream (the index is guessable)
+// cannot drive unbounded resends.
+func (l *handshakeLoop) onRetry(cookie []byte) {
+	if l.retriesHonored >= maxHonoredRetries {
+		return
+	}
+	flight := l.driver.cachedFlight()
+	if len(flight) == 0 || flight[0].typ != protocol.MessageTypeClientHello {
+		return
+	}
+	l.retriesHonored++
+	l.cookie = cookie
+	l.send(flight)
 }
 
 // maybeSurface publishes the session the instant it is established (so a responder
@@ -242,6 +282,12 @@ func (l *handshakeLoop) send(msgs []hsMessage) {
 			},
 			SenderIndex: l.localIndex,
 			MsgType:     m.typ,
+		}
+		// Echo the server's anti-DoS cookie only on the ClientHello; the server
+		// only ever demands it on the bootstrap flight, and later flights are
+		// already gated through by then (knownSource is true).
+		if m.typ == protocol.MessageTypeClientHello {
+			base.Cookie = l.cookie
 		}
 		frames, err := fragmentHandshake(base, m.body)
 		if err != nil {

--- a/pkg/tunnel/reassembly.go
+++ b/pkg/tunnel/reassembly.go
@@ -155,6 +155,16 @@ func (r *Reassembler) Drop(source string) {
 	r.mu.Unlock()
 }
 
+// sourceCount returns the number of sources with in-progress reassembly state.
+// The endpoint reads it as one of the cookie-pressure signals; it is only
+// consulted on the handshake-frame path (never the data hot path), so the lock
+// cost is irrelevant and a mirrored atomic is not worth the desync risk.
+func (r *Reassembler) sourceCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.bySource)
+}
+
 func (r *Reassembler) evictExpiredLocked() {
 	deadline := r.now().Add(-r.timeout)
 	for src, bufs := range r.bySource {

--- a/test/fuzz/datagram_fuzz_test.go
+++ b/test/fuzz/datagram_fuzz_test.go
@@ -1,0 +1,62 @@
+package fuzz
+
+import (
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// FuzzParseDatagramRetry exercises the RETRY frame parser an off-path attacker can
+// reach: a malformed RETRY must never panic, and a well-formed one must round-trip.
+func FuzzParseDatagramRetry(f *testing.F) {
+	f.Add(protocol.EncodeDatagramRetry(0, nil))
+	f.Add(protocol.EncodeDatagramRetry(0x01020304, []byte("cookie")))
+	f.Add([]byte{0x04})
+	f.Add([]byte(nil))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		idx, cookie, err := protocol.ParseDatagramRetry(data)
+		if err != nil {
+			return
+		}
+		// A successful parse must re-encode to a frame that parses back identically.
+		reenc := protocol.EncodeDatagramRetry(idx, cookie)
+		idx2, cookie2, err := protocol.ParseDatagramRetry(reenc)
+		if err != nil {
+			t.Fatalf("re-parse of a valid RETRY failed: %v", err)
+		}
+		if idx2 != idx || string(cookie2) != string(cookie) {
+			t.Fatalf("RETRY round-trip mismatch: (%d,%q) != (%d,%q)", idx2, cookie2, idx, cookie)
+		}
+	})
+}
+
+// FuzzParseDatagramHandshake exercises the handshake-frame parser, including the
+// cookie-bearing path used by the anti-DoS gate. Malformed input must never panic.
+func FuzzParseDatagramHandshake(f *testing.F) {
+	seed, _ := protocol.EncodeDatagramHandshake(protocol.DatagramHandshakeHeader{
+		SenderIndex: 7,
+		MsgType:     protocol.MessageTypeClientHello,
+		FragLength:  5,
+		TotalLength: 5,
+		Cookie:      []byte("a-cookie"),
+	}, []byte("hello"))
+	f.Add(seed)
+	f.Add([]byte{0x01})
+	f.Add([]byte(nil))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		h, fragment, err := protocol.ParseDatagramHandshake(data)
+		if err != nil {
+			return
+		}
+		// Invariants the parser must guarantee on success.
+		if int(h.FragLength) != len(fragment) {
+			t.Fatalf("FragLength %d != fragment len %d", h.FragLength, len(fragment))
+		}
+		if int(h.FragOffset)+int(h.FragLength) > int(h.TotalLength) {
+			t.Fatalf("fragment exceeds total: off=%d len=%d total=%d",
+				h.FragOffset, h.FragLength, h.TotalLength)
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds a load-gated, stateless return-routability cookie to the UDP/datagram handshake, closing the spoofed-source state/CPU-exhaustion gap and enforcing a strict anti-amplification bound. This is the first of two DoS-hardening PRs; authenticated roaming follows separately.

## Why

UDP source addresses are spoofable, so an off-path attacker could send `ClientHello`s with a forged source and make the server allocate per-source reassembly buffers, run an expensive CH-KEM `Encapsulate`, and reflect a ~1.6 KB `ServerHello` at a victim. The wire format already reserved `DatagramFrameRetry` and a handshake `Cookie` field for exactly this, so no wire change is needed.

## Design

The server demands a cookie only when under load (the QUIC `RETRY` posture), so honest handshakes add zero round trips in the common case.

- **Pre-reassembly gate.** The check sits in `routeDatagram` before `reasm.Add`, so a rejected frame allocates no reassembly buffer and runs no CH-KEM. The dominant exhaustion vector is reassembler occupancy (forged sources sending only a leading `ClientHello` fragment that never completes), so the gate has to precede reassembly, not follow handshake completion.
- **Pressure signal.** Either the in-progress reassembly source count or the global half-open count crossing `DatagramCookiePressureHighWater` (half the hard cap) trips cookie-required mode. The two signals are complementary: occupancy catches the partial-fragment flood, half-open catches a completed-ClientHello/CH-KEM flood.
- **Keyed on known-source, not RecvIndex.** The gate lets through only sources already tracked (established session by index, or in-progress responder by source). Gating on tracked-ness rather than `RecvIndex == 0` stops an attacker from dodging the gate by stamping a random nonzero `RecvIndex` on a spoofed bootstrap `ClientHello`.
- **Stateless cookie.** `HMAC-SHA256(secret, addr || issue_time)` with a per-endpoint CSPRNG secret and a 10s lifetime; constant-time verify; no per-source server state.
- **Strict anti-amplification.** A RETRY is 54 bytes and is sent only for a `ClientHello` first fragment and only when it is no larger than the triggering datagram, so it can never be an amplifier even against a runt fragment.
- **Client.** The initiator adopts the cookie from a RETRY and re-sends its `ClientHello` carrying it, bounded to a few honored RETRYs so a forged RETRY stream (the index is guessable) cannot drive unbounded resends.

## Tests

Cookie issue/verify/expiry/binding/tamper; `knownSource` and global half-open accounting; pressure threshold; a spoofed-source flood that creates zero sessions and zero reassembly sources and only emits de-amplifying RETRYs; a runt-fragment no-RETRY floor; valid-cookie admission; RETRY delivery to the initiator; and a full handshake completing through the gate under forced pressure. Fuzz targets for the RETRY and handshake parsers. Full suite green under `-race`; golangci-lint and gofmt clean.

## Docs

New `docs/datagram-dos.md` threat model; cross-linked from `docs/datagram-transport.md` and its status table updated.

## Out of scope (follow-up PR)

Authenticated roaming; periodic in-process cookie-secret rotation; per-source (vs endpoint-wide) pressure scoping.
