### PR TITLE
follow a roaming peer to its new address on an authenticated datagram

### DIFF
--- a/docs/datagram-dos.md
+++ b/docs/datagram-dos.md
@@ -77,9 +77,37 @@ which the off-path attacker cannot receive.
   and invalidates outstanding cookies, costing one extra `RETRY` round trip on the
   next attempt. Periodic in-process rotation (with a two-generation accept window
   so a rotation does not invalidate in-flight cookies) is future work.
-- **Roaming authentication** (binding a moved peer address to an
-  AEAD-authenticated, replay-fresh frame) is tracked separately and not part of
-  this hardening.
+- **Per-source pressure scoping** and a deeper anti-amplification budget are
+  future refinements.
+
+## Authenticated roaming
+
+A datagram session is demultiplexed by its connection index, not its source
+address, so it can survive a peer changing address (NAT rebind, network change).
+The receive loop advances the session's send address (`peerAddr`) to a new source
+only when a DATA frame from that source both authenticates (AEAD Open succeeds)
+and is replay-fresh (passes the replay window's `Check`). See `routeDatagram` in
+`pkg/tunnel/datagram.go`.
+
+Gating the address update on the replay-window `Check` is what makes roaming safe:
+
+- A captured frame replayed from an attacker-controlled address fails `Check`
+  (the sequence is already recorded), so an off-path attacker cannot steer the
+  session to an address it controls, even though it can copy ciphertext verbatim.
+- A forged frame fails AEAD Open, so it never reaches the address update and never
+  advances the replay window (the window is recorded only after authentication).
+- Only the genuine peer, which holds the send key and produces fresh sequence
+  numbers, can move the path.
+
+`peerAddr` is an atomic pointer: the receive loop is the sole writer, while the
+send and rekey goroutines read it lock-free, so roaming adds no contention to the
+data send path. `DatagramConn.RemoteAddr` reflects the current address and so
+follows the peer across a roam.
+
+Residual: there is no explicit path-validation challenge before adopting a new
+address (the authenticated-and-fresh test is the validation). An on-path attacker
+who can both observe and inject within the live sequence window is out of scope,
+as it is for the data plane generally.
 
 ## Tests
 

--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -22,8 +22,8 @@ is updated as pieces land.
 | Data path (DatagramConn Send/Recv/Close) + idle reaper | `pkg/tunnel/dgram_conn.go`, `datagram.go` | implemented |
 | Reliable rekey transport (fragmented sub-handshake) | `pkg/tunnel/dgram_rekey.go` | implemented |
 | Zero-alloc / batched I/O | - | future |
-| Stateless cookie / anti-amplification | done |
-| Authenticated roaming | future |
+| Stateless cookie / anti-amplification | `pkg/tunnel/dgram_cookie.go`, `datagram.go` | implemented |
+| Authenticated roaming | `pkg/tunnel/datagram.go` | implemented |
 
 ## Wire format
 
@@ -113,10 +113,12 @@ needs no wire change.
 
 Amplification is inherently low: the ~1.7 KB ClientHello must be fully received
 and reassembled before the comparable ServerHello is sent (response:request ≈
-1:1, not an amplifier). The current implementation additionally reuses the
-existing rate limiters and caps concurrent half-open handshakes per source and
-overall. A future stateless cookie will close the residual spoofed-source
-state-exhaustion gap and enforce a strict anti-amplification bound.
+1:1, not an amplifier). The implementation additionally reuses the existing rate
+limiters and caps concurrent half-open handshakes per source and overall. A
+load-gated stateless cookie closes the residual spoofed-source state-exhaustion
+gap and enforces a strict anti-amplification bound, and a session follows a
+roaming peer only on an authenticated, replay-fresh frame; see
+[datagram-dos.md](datagram-dos.md).
 
 ## Out of scope (future)
 

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -44,16 +44,21 @@ type datagramSession struct {
 	inbox   chan inboundMsg // reassembled handshake messages for this session's goroutine
 	session *Session        // set once the handshake establishes
 
-	// Set once at establishment, then read-only. peerIndex is the index the peer
-	// assigned to us (we echo it as RecvIndex when sending so the peer demuxes by
-	// it); peerAddr is the peer's current address (the data-path send target, and
-	// the rebinding anchor for roaming); recvCh delivers decrypted application
-	// payloads to the DatagramConn.
+	// peerIndex is the index the peer assigned to us (we echo it as RecvIndex when
+	// sending so the peer demuxes by it); set once at establishment, then read-only.
+	// recvCh delivers decrypted application payloads to the DatagramConn.
 	peerIndex uint32
-	peerAddr  net.Addr
 	recvCh    chan []byte
 	closed    chan struct{}
 	closeOnce sync.Once
+
+	// peerAddr is the peer's current address: the data-path send target and the
+	// roaming anchor. Unlike peerIndex it is mutable - the receive loop advances it
+	// when an AEAD-authenticated, replay-fresh frame arrives from a new source (see
+	// routeDatagram), so a session follows a peer across NAT rebind/roaming. It is
+	// atomic because the receive loop writes it while the send/rekey goroutines read
+	// it. Access only via currentPeerAddr/setPeerAddr.
+	peerAddr atomic.Pointer[net.Addr]
 
 	// Rekey transport state. The initiator (handshake RoleInitiator) drives rekey
 	// from a goroutine and reads RekeyResponse bodies off rekeyInbox; the responder
@@ -73,6 +78,17 @@ type datagramSession struct {
 	// cookie. Only the initiator (DialDatagram) creates it.
 	retryCh chan []byte
 }
+
+// currentPeerAddr returns the peer's current send address, or nil if unset.
+func (ds *datagramSession) currentPeerAddr() net.Addr {
+	if p := ds.peerAddr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setPeerAddr updates the peer's send address (roaming, or the initial set).
+func (ds *datagramSession) setPeerAddr(a net.Addr) { ds.peerAddr.Store(&a) }
 
 // beginRekey claims the single initiator rekey slot, returning false if one is
 // already in flight.
@@ -117,6 +133,21 @@ func newConnRegistry() *connRegistry {
 		bySource: make(map[string]*datagramSession),
 		halfOpen: make(map[string]int),
 	}
+}
+
+// addrEqual reports whether two peer addresses are the same endpoint. It compares
+// *net.UDPAddr without allocating (the data hot path runs it per received frame to
+// detect roaming) and falls back to String() for other net.Addr implementations.
+func addrEqual(a, b net.Addr) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	au, aok := a.(*net.UDPAddr)
+	bu, bok := b.(*net.UDPAddr)
+	if aok && bok {
+		return au.Port == bu.Port && au.IP.Equal(bu.IP) && au.Zone == bu.Zone
+	}
+	return a.String() == b.String()
 }
 
 // randIndex draws a non-zero random 32-bit connection index. Index 0 is reserved
@@ -443,6 +474,14 @@ func (e *DatagramEndpoint) routeDatagram(src net.Addr, data []byte) error {
 		}
 		if !ds.session.dgramReplay.Check(hdr.Seq) {
 			return nil // duplicate that slipped past the peek: drop
+		}
+		// Authenticated roaming: a frame that authenticated AND was replay-fresh is
+		// proof the peer holds the send key and is live at src, so follow it there if
+		// it moved (NAT rebind / roaming). Gating on Check is what makes this safe -
+		// a replayed captured frame fails Check above, so an off-path attacker cannot
+		// steer the session to an address it controls.
+		if !addrEqual(ds.currentPeerAddr(), src) {
+			ds.setPeerAddr(src)
 		}
 		ds.session.BytesReceived.Add(int64(len(pt)))
 		ds.session.PacketsRecv.Add(1)

--- a/pkg/tunnel/dgram_conn.go
+++ b/pkg/tunnel/dgram_conn.go
@@ -22,14 +22,13 @@ import (
 // not safe for concurrent callers (it shares no buffer in this phase, but the
 // contract is reserved for the zero-alloc path).
 type DatagramConn struct {
-	ep   *DatagramEndpoint
-	ds   *datagramSession
-	peer net.Addr
+	ep *DatagramEndpoint
+	ds *datagramSession
 }
 
 // newDatagramConn wraps an established datagram session.
 func newDatagramConn(ep *DatagramEndpoint, ds *datagramSession) *DatagramConn {
-	return &DatagramConn{ep: ep, ds: ds, peer: ds.peerAddr}
+	return &DatagramConn{ep: ep, ds: ds}
 }
 
 // Send encrypts p into a single DATA datagram and writes it to the peer. It
@@ -52,7 +51,7 @@ func (c *DatagramConn) Send(p []byte) error {
 		return err
 	}
 	frame := append(header, ct...)
-	if _, err := c.ep.conn.WriteTo(frame, c.peer); err != nil {
+	if _, err := c.ep.conn.WriteTo(frame, c.ds.currentPeerAddr()); err != nil {
 		return err
 	}
 	s.BytesSent.Add(int64(len(p)))
@@ -92,7 +91,7 @@ func (c *DatagramConn) Close() error {
 			Seq:       seq,
 		})
 		if tag, err := s.DatagramSeal(header, seq, nil); err == nil {
-			_, _ = c.ep.conn.WriteTo(append(header, tag...), c.peer)
+			_, _ = c.ep.conn.WriteTo(append(header, tag...), c.ds.currentPeerAddr())
 		}
 		s.Close()
 	}
@@ -100,8 +99,10 @@ func (c *DatagramConn) Close() error {
 	return nil
 }
 
-// RemoteAddr returns the peer's current address.
-func (c *DatagramConn) RemoteAddr() net.Addr { return c.peer }
+// RemoteAddr returns the peer's current address, which follows the peer across
+// roaming (NAT rebind / path change), so it may differ from the dial/accept
+// address after the peer moves.
+func (c *DatagramConn) RemoteAddr() net.Addr { return c.ds.currentPeerAddr() }
 
 // Session exposes the underlying Session (statistics, state).
 func (c *DatagramConn) Session() *Session { return c.ds.session }

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -80,11 +80,11 @@ func (e *DatagramEndpoint) startResponder(src net.Addr, first inboundMsg) {
 		return
 	}
 	ds := &datagramSession{
-		inbox:    make(chan inboundMsg, inboxCap),
-		peerAddr: src,
-		recvCh:   make(chan []byte, dataInboxCap),
-		closed:   make(chan struct{}),
+		inbox:  make(chan inboundMsg, inboxCap),
+		recvCh: make(chan []byte, dataInboxCap),
+		closed: make(chan struct{}),
 	}
+	ds.setPeerAddr(src)
 	idx, err := e.registry.add(ds)
 	if err != nil {
 		e.registry.releaseHalfOpen(src.String())
@@ -114,12 +114,12 @@ func DialDatagram(ep *DatagramEndpoint, dst net.Addr) (*DatagramConn, error) {
 	}
 	ds := &datagramSession{
 		inbox:      make(chan inboundMsg, inboxCap),
-		peerAddr:   dst,
 		recvCh:     make(chan []byte, dataInboxCap),
 		closed:     make(chan struct{}),
 		rekeyInbox: make(chan []byte, 4),
 		retryCh:    make(chan []byte, 1),
 	}
+	ds.setPeerAddr(dst)
 	idx, err := ep.registry.add(ds)
 	if err != nil {
 		return nil, err

--- a/pkg/tunnel/dgram_rekey.go
+++ b/pkg/tunnel/dgram_rekey.go
@@ -240,8 +240,9 @@ func (c *DatagramConn) Rekey() error {
 			if attempts > constants.DatagramHandshakeMaxRetries {
 				return errRekeyTimeout
 			}
+			peer := c.ds.currentPeerAddr() // re-read so a mid-rekey roam is followed
 			for _, f := range frames {
-				_, _ = c.ep.conn.WriteTo(f, c.peer)
+				_, _ = c.ep.conn.WriteTo(f, peer)
 			}
 			attempts++
 			armTimer(timer, rto)
@@ -291,8 +292,9 @@ func (e *DatagramEndpoint) handleRekeyInit(ds *datagramSession, epoch uint8, bod
 	defer ds.rekeyRespMu.Unlock()
 
 	if ds.rekeyRespValid && ds.rekeyRespFrom == epoch {
+		peer := ds.currentPeerAddr()
 		for _, f := range ds.rekeyRespFrames {
-			_, _ = e.conn.WriteTo(f, ds.peerAddr)
+			_, _ = e.conn.WriteTo(f, peer)
 		}
 		return
 	}
@@ -312,7 +314,8 @@ func (e *DatagramEndpoint) handleRekeyInit(ds *datagramSession, epoch uint8, bod
 	ds.rekeyRespFrom = epoch
 	ds.rekeyRespFrames = frames
 	ds.rekeyRespValid = true
+	peer := ds.currentPeerAddr()
 	for _, f := range frames {
-		_, _ = e.conn.WriteTo(f, ds.peerAddr)
+		_, _ = e.conn.WriteTo(f, peer)
 	}
 }

--- a/pkg/tunnel/dgram_roaming_test.go
+++ b/pkg/tunnel/dgram_roaming_test.go
@@ -1,0 +1,160 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+func udp(ip string, port int) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(ip), Port: port}
+}
+
+func TestAddrEqual(t *testing.T) {
+	a := udp("203.0.113.1", 5000)
+	if !addrEqual(a, udp("203.0.113.1", 5000)) {
+		t.Fatal("identical UDP addresses must compare equal")
+	}
+	if addrEqual(a, udp("203.0.113.1", 5001)) {
+		t.Fatal("different ports must compare unequal")
+	}
+	if addrEqual(a, udp("203.0.113.2", 5000)) {
+		t.Fatal("different IPs must compare unequal")
+	}
+	if addrEqual(nil, a) || addrEqual(a, nil) {
+		t.Fatal("nil must not equal a real address")
+	}
+	if !addrEqual(nil, nil) {
+		t.Fatal("nil must equal nil")
+	}
+	// Non-UDP addrs fall back to String().
+	if !addrEqual(memAddr{name: "x"}, memAddr{name: "x"}) {
+		t.Fatal("equal memAddrs must compare equal")
+	}
+}
+
+// dataFrameFrom seals a DATA frame from `from` targeting connection index idx at
+// sequence seq, returning the wire bytes the receive loop would see.
+func dataFrameFrom(t *testing.T, from *Session, idx uint32, seq uint64, payload []byte) []byte {
+	t.Helper()
+	header := protocol.EncodeDatagramHeader(protocol.DatagramHeader{
+		Type:      protocol.DatagramFrameData,
+		Epoch:     from.datagramSendEpoch(),
+		RecvIndex: idx,
+		Seq:       seq,
+	})
+	ct, err := from.DatagramSeal(header, seq, payload)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return append(header, ct...)
+}
+
+// registerEstablished registers an established responder-side session in e's
+// registry whose peer is the initiator session, anchored at addr.
+func registerEstablished(t *testing.T, e *DatagramEndpoint, addr net.Addr) (idx uint32, peer *Session, ds *datagramSession) {
+	t.Helper()
+	initiator, responder := datagramSessionPair(t)
+	ds = &datagramSession{
+		session: responder,
+		recvCh:  make(chan []byte, 8),
+		closed:  make(chan struct{}),
+	}
+	ds.setPeerAddr(addr)
+	idx, err := e.registry.add(ds)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return idx, initiator, ds
+}
+
+func TestRoamingFollowsAuthenticatedFrame(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	start := udp("198.51.100.1", 4000)
+	idx, peer, ds := registerEstablished(t, e, start)
+
+	// A fresh authenticated frame from a new source moves the session there.
+	moved := udp("203.0.113.9", 7000)
+	if err := e.routeDatagram(moved, dataFrameFrom(t, peer, idx, 1, []byte("one"))); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	if got := ds.currentPeerAddr(); !addrEqual(got, moved) {
+		t.Fatalf("peerAddr = %v after authenticated roam, want %v", got, moved)
+	}
+	// The payload was still delivered.
+	select {
+	case <-ds.recvCh:
+	default:
+		t.Fatal("roamed frame was not delivered to the application")
+	}
+}
+
+func TestRoamingIgnoresReplayedFrame(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	start := udp("198.51.100.1", 4000)
+	idx, peer, ds := registerEstablished(t, e, start)
+
+	frame := dataFrameFrom(t, peer, idx, 1, []byte("one"))
+	if err := e.routeDatagram(start, frame); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	if got := ds.currentPeerAddr(); !addrEqual(got, start) {
+		t.Fatalf("peerAddr = %v after first frame, want %v", got, start)
+	}
+
+	// Replaying the exact same (already-seen) frame from an attacker address must
+	// fail the replay window and therefore NOT move the session.
+	attacker := udp("203.0.113.66", 9999)
+	if err := e.routeDatagram(attacker, frame); err != nil {
+		t.Fatalf("route replay: %v", err)
+	}
+	if got := ds.currentPeerAddr(); !addrEqual(got, start) {
+		t.Fatalf("replayed frame moved peerAddr to %v; must stay %v", got, start)
+	}
+}
+
+func TestRoamingIgnoresForgedFrame(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	start := udp("198.51.100.1", 4000)
+	idx, peer, ds := registerEstablished(t, e, start)
+
+	// A frame whose ciphertext is corrupt fails AEAD Open, so the session must not
+	// move and the replay window must not advance.
+	frame := dataFrameFrom(t, peer, idx, 5, []byte("real"))
+	frame[len(frame)-1] ^= 0xff // tamper the tag
+	attacker := udp("203.0.113.66", 9999)
+	if err := e.routeDatagram(attacker, frame); err != nil {
+		t.Fatalf("route forged: %v", err)
+	}
+	if got := ds.currentPeerAddr(); !addrEqual(got, start) {
+		t.Fatalf("forged frame moved peerAddr to %v; must stay %v", got, start)
+	}
+
+	// A subsequent genuine frame at seq 5 from the real peer still authenticates
+	// (the forged attempt did not consume the sequence) and roams.
+	good := udp("203.0.113.9", 7000)
+	if err := e.routeDatagram(good, dataFrameFrom(t, peer, idx, 5, []byte("real"))); err != nil {
+		t.Fatalf("route good: %v", err)
+	}
+	if got := ds.currentPeerAddr(); !addrEqual(got, good) {
+		t.Fatalf("peerAddr = %v after genuine roam, want %v", got, good)
+	}
+}
+
+func TestRoamingNoChangeSameSource(t *testing.T) {
+	e := mustEndpoint(t, &captureConn{})
+	start := udp("198.51.100.1", 4000)
+	idx, peer, ds := registerEstablished(t, e, start)
+
+	before := ds.currentPeerAddr()
+	for seq := uint64(1); seq <= 3; seq++ {
+		if err := e.routeDatagram(start, dataFrameFrom(t, peer, idx, seq, []byte("x"))); err != nil {
+			t.Fatalf("route: %v", err)
+		}
+	}
+	// Same-source traffic must not churn the stored pointer's identity.
+	if got := ds.currentPeerAddr(); !addrEqual(got, before) {
+		t.Fatalf("same-source traffic changed peerAddr to %v, want %v", got, before)
+	}
+}


### PR DESCRIPTION
## What

Makes a datagram session follow its peer when the peer's source address changes (NAT rebind, network/path change). This is the second of the two DoS-hardening PRs; the first (PR #45) added the load-gated stateless cookie.

## Why

The datagram transport already demultiplexes by a random connection index rather than by source address, so a session can in principle survive a peer moving. Until now the peer's send address was fixed at establishment, so once a peer roamed the server kept sending to the old address and the path broke. This wires up the address update, safely.

## Design

The receive loop advances the session's stored `peerAddr` to a new source only when a DATA frame from that source both authenticates (AEAD Open succeeds) and is replay-fresh (passes the replay window's `Check`). The update happens at the commit point in `routeDatagram`, after both checks pass.

Gating on the replay-window `Check` is what makes this safe:

- A captured frame replayed from an attacker-controlled address fails `Check` (the sequence is already recorded), so an off-path attacker cannot steer the session to an address it controls even though it can copy ciphertext verbatim.
- A forged frame fails AEAD Open, so it never reaches the address update and never advances the replay window (the window is recorded only after authentication).
- Only the genuine peer, which holds the send key and produces fresh sequence numbers, can move the path.

`peerAddr` becomes an `atomic.Pointer[net.Addr]`: the receive loop is the sole writer; the send, close, and rekey goroutines read it lock-free, so roaming adds no contention to the data send path. All send sites (`DatagramConn.Send`/`Close`, `RemoteAddr`, the rekey initiator and responder-cache replays) now read the live address, so a mid-session roam is followed everywhere. The stale per-conn address copy is removed. Address comparison is allocation-free for `*net.UDPAddr` on the hot path.

## Tests

`addrEqual` (UDP equality, nil, non-UDP fallback); an authenticated frame from a new source moves the session and still delivers the payload; a replayed frame does not move it; a forged (tampered-tag) frame neither moves it nor consumes the sequence, and a subsequent genuine frame still roams; same-source traffic does not churn the address. Full suite green under `-race`; golangci-lint and gofmt clean.

## Docs

`docs/datagram-dos.md` gains an "Authenticated roaming" section; the transport status table is updated (and its two cookie/roaming rows fixed to the table's 3-column format).

## Out of scope

Explicit path-validation challenge before adopting a new address (the authenticated-and-fresh test is the validation); periodic in-process cookie-secret rotation; per-source pressure scoping. With this merged, the remaining datagram work is performance (zero-alloc AEAD, batched syscalls, benchmark) and optional fixed-size padding.
