### PR TITLE
build datagram send frames in a reusable zero-alloc buffer

### DIFF
--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -21,7 +21,8 @@ is updated as pieces land.
 | Epoch cipher selection + derived-nonce seal/open | `pkg/tunnel/dgram_session.go` | implemented |
 | Data path (DatagramConn Send/Recv/Close) + idle reaper | `pkg/tunnel/dgram_conn.go`, `datagram.go` | implemented |
 | Reliable rekey transport (fragmented sub-handshake) | `pkg/tunnel/dgram_rekey.go` | implemented |
-| Zero-alloc / batched I/O | - | future |
+| Zero-alloc in-place AEAD send path | `pkg/crypto/aead_inplace.go`, `pkg/tunnel/dgram_session_inplace.go`, `dgram_conn.go` | implemented |
+| Batched recvmmsg/sendmmsg I/O | - | future |
 | Stateless cookie / anti-amplification | `pkg/tunnel/dgram_cookie.go`, `datagram.go` | implemented |
 | Authenticated roaming | `pkg/tunnel/datagram.go` | implemented |
 

--- a/pkg/crypto/aead_inplace.go
+++ b/pkg/crypto/aead_inplace.go
@@ -1,0 +1,42 @@
+package crypto
+
+import (
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
+)
+
+// SealWithNonceTo encrypts plaintext under nonce and appends the ciphertext and
+// authentication tag to dst, returning the extended slice. Unlike SealWithNonce
+// (which allocates a fresh slice per call), the caller supplies dst: pass a slice
+// with spare capacity (for the datagram path, the frame buffer already holding the
+// header) and the result reuses that backing array with no allocation. dst and
+// plaintext must not overlap.
+//
+// To build a datagram frame in place, pass dst = header (len 14, cap >= 14 +
+// len(plaintext) + Overhead) so the returned slice is header||ciphertext||tag and
+// the AEAD AAD is that same header.
+func (a *AEAD) SealWithNonceTo(dst, nonce, plaintext, additionalData []byte) ([]byte, error) {
+	if len(nonce) != constants.AESNonceSize {
+		return nil, qerrors.ErrInvalidNonce
+	}
+	return a.cipher.Seal(dst, nonce, plaintext, additionalData), nil
+}
+
+// OpenWithNonceTo decrypts ciphertext under nonce and appends the plaintext to
+// dst, returning the extended slice. Unlike OpenWithNonce it does not allocate
+// when dst has spare capacity. The decrypted plaintext is written after any
+// existing dst contents; pass dst[:0] over a reusable buffer to overwrite. dst and
+// ciphertext must not overlap.
+func (a *AEAD) OpenWithNonceTo(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	if len(nonce) != constants.AESNonceSize {
+		return nil, qerrors.ErrInvalidNonce
+	}
+	if len(ciphertext) < constants.AESTagSize {
+		return nil, qerrors.ErrCiphertextTooShort
+	}
+	pt, err := a.cipher.Open(dst, nonce, ciphertext, additionalData)
+	if err != nil {
+		return nil, qerrors.ErrAuthenticationFailed
+	}
+	return pt, nil
+}

--- a/pkg/crypto/aead_inplace_test.go
+++ b/pkg/crypto/aead_inplace_test.go
@@ -1,0 +1,109 @@
+package crypto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+)
+
+func newTestAEAD(t *testing.T) *AEAD {
+	t.Helper()
+	key := make([]byte, constants.AESKeySize)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	a, err := NewAEAD(constants.CipherSuiteAES256GCM, key)
+	if err != nil {
+		t.Fatalf("NewAEAD: %v", err)
+	}
+	return a
+}
+
+func TestSealOpenWithNonceToRoundTrip(t *testing.T) {
+	a := newTestAEAD(t)
+	nonce := make([]byte, a.NonceSize())
+	aad := []byte("header-aad")
+	pt := []byte("the quick brown fox")
+
+	// Seal appending after a header prefix, exactly as the datagram frame path does.
+	header := append([]byte(nil), aad...)
+	frame, err := a.SealWithNonceTo(header, nonce, pt, aad)
+	if err != nil {
+		t.Fatalf("SealWithNonceTo: %v", err)
+	}
+	if !bytes.Equal(frame[:len(aad)], aad) {
+		t.Fatal("SealWithNonceTo overwrote the dst prefix")
+	}
+	ct := frame[len(aad):]
+
+	// Cross-check against the allocating SealWithNonce.
+	want, err := a.SealWithNonce(nonce, pt, aad)
+	if err != nil {
+		t.Fatalf("SealWithNonce: %v", err)
+	}
+	if !bytes.Equal(ct, want) {
+		t.Fatal("SealWithNonceTo ciphertext differs from SealWithNonce")
+	}
+
+	// Open back into a reusable buffer.
+	out := make([]byte, 0, len(pt))
+	got, err := a.OpenWithNonceTo(out, nonce, ct, aad)
+	if err != nil {
+		t.Fatalf("OpenWithNonceTo: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, pt)
+	}
+}
+
+func TestWithNonceToRejectsBadNonce(t *testing.T) {
+	a := newTestAEAD(t)
+	short := make([]byte, a.NonceSize()-1)
+	if _, err := a.SealWithNonceTo(nil, short, []byte("x"), nil); err == nil {
+		t.Fatal("SealWithNonceTo accepted a short nonce")
+	}
+	if _, err := a.OpenWithNonceTo(nil, short, []byte("x"), nil); err == nil {
+		t.Fatal("OpenWithNonceTo accepted a short nonce")
+	}
+}
+
+func TestWithNonceToRejectsTampered(t *testing.T) {
+	a := newTestAEAD(t)
+	nonce := make([]byte, a.NonceSize())
+	aad := []byte("aad")
+	ct, err := a.SealWithNonceTo(nil, nonce, []byte("secret"), aad)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	ct[len(ct)-1] ^= 0xff
+	if _, err := a.OpenWithNonceTo(nil, nonce, ct, aad); err == nil {
+		t.Fatal("OpenWithNonceTo accepted a tampered tag")
+	}
+}
+
+// BenchmarkSealWithNonce contrasts the allocating and zero-alloc seal paths so the
+// alloc/op delta is visible (run with -benchmem).
+func BenchmarkSealWithNonce(b *testing.B) {
+	key := make([]byte, constants.AESKeySize)
+	a, _ := NewAEAD(constants.CipherSuiteAES256GCM, key)
+	nonce := make([]byte, a.NonceSize())
+	aad := make([]byte, 14)
+	pt := make([]byte, 1200)
+
+	b.Run("Alloc", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = a.SealWithNonce(nonce, pt, aad)
+		}
+	})
+
+	b.Run("InPlace", func(b *testing.B) {
+		b.ReportAllocs()
+		buf := make([]byte, len(aad), len(aad)+len(pt)+a.Overhead())
+		copy(buf, aad)
+		for i := 0; i < b.N; i++ {
+			_, _ = a.SealWithNonceTo(buf[:len(aad)], nonce, pt, aad)
+		}
+	})
+}

--- a/pkg/protocol/datagram_inplace.go
+++ b/pkg/protocol/datagram_inplace.go
@@ -1,0 +1,16 @@
+package protocol
+
+// AppendDatagramDataHeader appends the 14-byte common DATA-frame header for h to
+// dst and returns the extended slice. It forces h.Type to DatagramFrameData. The
+// header is written directly into the (grown) dst with no temporary buffer - the
+// `append(dst, make(...)...)` form is special-cased by the compiler to avoid
+// allocating the make'd slice - so with a dst that has spare capacity this adds no
+// heap allocation. The datagram send hot path uses it to build a frame header in a
+// reusable buffer before sealing the payload in place after it.
+func AppendDatagramDataHeader(dst []byte, h DatagramHeader) []byte {
+	h.Type = DatagramFrameData
+	off := len(dst)
+	dst = append(dst, make([]byte, DatagramHeaderSize)...)
+	putDatagramHeader(dst[off:], h)
+	return dst
+}

--- a/pkg/tunnel/dgram_conn.go
+++ b/pkg/tunnel/dgram_conn.go
@@ -24,11 +24,20 @@ import (
 type DatagramConn struct {
 	ep *DatagramEndpoint
 	ds *datagramSession
+
+	// sendBuf is the reusable frame buffer for Send (header || ciphertext || tag),
+	// retained across calls so the steady-state send path allocates nothing. Send
+	// is single-goroutine by contract, so it needs no lock.
+	sendBuf []byte
 }
 
 // newDatagramConn wraps an established datagram session.
 func newDatagramConn(ep *DatagramEndpoint, ds *datagramSession) *DatagramConn {
-	return &DatagramConn{ep: ep, ds: ds}
+	return &DatagramConn{
+		ep:      ep,
+		ds:      ds,
+		sendBuf: make([]byte, 0, constants.DatagramMTU),
+	}
 }
 
 // Send encrypts p into a single DATA datagram and writes it to the peer. It
@@ -40,17 +49,19 @@ func (c *DatagramConn) Send(p []byte) error {
 	}
 	s := c.ds.session
 	seq := s.nextDatagramSeq()
-	header := protocol.EncodeDatagramHeader(protocol.DatagramHeader{
-		Type:      protocol.DatagramFrameData,
+	// Build header || ciphertext || tag in the reusable buffer: the header is both
+	// the frame prefix and the AEAD AAD, and DatagramSealTo appends the sealed
+	// payload after it in place, so the steady-state send path allocates nothing.
+	header := protocol.AppendDatagramDataHeader(c.sendBuf[:0], protocol.DatagramHeader{
 		Epoch:     s.datagramSendEpoch(),
 		RecvIndex: c.ds.peerIndex,
 		Seq:       seq,
 	})
-	ct, err := s.DatagramSeal(header, seq, p)
+	frame, err := s.DatagramSealTo(header, header, seq, p)
 	if err != nil {
 		return err
 	}
-	frame := append(header, ct...)
+	c.sendBuf = frame[:0] // retain the (grown) backing array for the next Send
 	if _, err := c.ep.conn.WriteTo(frame, c.ds.currentPeerAddr()); err != nil {
 		return err
 	}

--- a/pkg/tunnel/dgram_session_inplace.go
+++ b/pkg/tunnel/dgram_session_inplace.go
@@ -1,0 +1,62 @@
+// Package tunnel - dgram_session_inplace.go adds zero-allocation variants of the
+// datagram seal/open primitives. They mirror DatagramSeal/DatagramOpen but append
+// into a caller-supplied buffer (via the crypto package's *WithNonceTo methods)
+// instead of allocating a fresh slice per call, so the datagram send hot path can
+// reuse one frame buffer per connection. The allocating variants remain for
+// callers that do not own a reusable buffer.
+package tunnel
+
+import (
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
+)
+
+// DatagramSealTo seals plaintext for the current epoch under nonce = sendPrefix ||
+// seq, authenticating aad, and appends ciphertext||tag to dst, returning the
+// extended slice. To build a frame in place pass dst = the header bytes (whose
+// content must equal aad) backed by an array with spare capacity, so the result is
+// header||ciphertext||tag with no allocation. See DatagramSeal for the semantics.
+func (s *Session) DatagramSealTo(dst, aad []byte, seq uint64, plaintext []byte) ([]byte, error) {
+	s.mu.RLock()
+	cur := s.dgramEpochs.cur
+	prefix := s.sendNoncePrefix
+	s.mu.RUnlock()
+	if cur == nil || cur.sendCipher == nil {
+		return nil, qerrors.ErrInvalidState
+	}
+	if seq-cur.startSeq >= constants.MaxPacketsBeforeRekey {
+		return nil, qerrors.ErrNonceExhausted
+	}
+	var nonce [constants.AESNonceSize]byte
+	datagramNonce(nonce[:], prefix, seq)
+	out, err := cur.sendCipher.SealWithNonceTo(dst, nonce[:], plaintext, aad)
+	if err != nil {
+		return nil, err
+	}
+	s.lastActivityNanos.Store(time.Now().UnixNano())
+	return out, nil
+}
+
+// DatagramOpenTo decrypts ciphertext for the epoch named in the frame header and
+// appends the plaintext to dst, returning the extended slice. It mirrors
+// DatagramOpen but does not allocate when dst has spare capacity. The caller still
+// performs the replay-window check.
+func (s *Session) DatagramOpenTo(dst []byte, epoch uint8, seq uint64, ciphertext, aad []byte) ([]byte, error) {
+	s.mu.RLock()
+	cipher := s.datagramRecvCipherLocked(epoch)
+	prefix := s.recvNoncePrefix
+	s.mu.RUnlock()
+	if cipher == nil {
+		return nil, qerrors.ErrAuthenticationFailed
+	}
+	var nonce [constants.AESNonceSize]byte
+	datagramNonce(nonce[:], prefix, seq)
+	pt, err := cipher.OpenWithNonceTo(dst, nonce[:], ciphertext, aad)
+	if err != nil {
+		return nil, err
+	}
+	s.lastActivityNanos.Store(time.Now().UnixNano())
+	return pt, nil
+}

--- a/pkg/tunnel/dgram_throughput_test.go
+++ b/pkg/tunnel/dgram_throughput_test.go
@@ -1,0 +1,74 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+)
+
+// discardConn is a net.PacketConn whose WriteTo discards instantly and whose
+// ReadFrom blocks until close. It isolates the send-path CPU/alloc cost from any
+// real socket so a benchmark measures framing + AEAD, not the kernel.
+type discardConn struct{ closed chan struct{} }
+
+func newDiscardConn() *discardConn { return &discardConn{closed: make(chan struct{})} }
+
+func (c *discardConn) WriteTo(p []byte, _ net.Addr) (int, error) { return len(p), nil }
+func (c *discardConn) ReadFrom([]byte) (int, net.Addr, error) {
+	<-c.closed
+	return 0, nil, net.ErrClosed
+}
+func (c *discardConn) Close() error                     { close(c.closed); return nil }
+func (c *discardConn) LocalAddr() net.Addr              { return memAddr{name: "discard"} }
+func (c *discardConn) SetDeadline(time.Time) error      { return nil }
+func (c *discardConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *discardConn) SetWriteDeadline(time.Time) error { return nil }
+
+// benchDatagramConn builds an established DatagramConn over a discard conn without
+// running a handshake: it keys an initiator session directly so Send has a live
+// epoch cipher.
+func benchDatagramConn(b *testing.B) *DatagramConn {
+	b.Helper()
+	s, err := NewSession(RoleInitiator)
+	if err != nil {
+		b.Fatalf("session: %v", err)
+	}
+	ms := make([]byte, constants.CHKEMSharedSecretSize)
+	for i := range ms {
+		ms[i] = byte(i)
+	}
+	if err := s.InitializeDatagramKeys(ms, constants.CipherSuiteAES256GCM); err != nil {
+		b.Fatalf("keys: %v", err)
+	}
+	ep, err := NewDatagramEndpoint(newDiscardConn())
+	if err != nil {
+		b.Fatalf("endpoint: %v", err)
+	}
+	ds := &datagramSession{
+		session:   s,
+		peerIndex: 0x1234,
+		recvCh:    make(chan []byte, 1),
+		closed:    make(chan struct{}),
+	}
+	ds.setPeerAddr(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9})
+	return newDatagramConn(ep, ds)
+}
+
+// BenchmarkDatagramSend measures the steady-state send path. The frame buffer
+// (header || ciphertext || tag) is reused with no allocation; the single residual
+// alloc/op is the 12-byte nonce, which escapes to the heap through Go's cipher.AEAD
+// interface boundary and is inherent to the standard library (run with -benchmem).
+func BenchmarkDatagramSend(b *testing.B) {
+	c := benchDatagramConn(b)
+	payload := make([]byte, 1200-constants.DatagramDataOverhead)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.Send(payload); err != nil {
+			b.Fatalf("send: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## What

Makes the datagram data send path reuse a single per-connection frame buffer and seal each frame into it in place, eliminating the per-datagram header, ciphertext, and frame allocations. Adds the zero-alloc AEAD primitives behind it and a throughput benchmark. First of the datagram performance changes; batched recvmmsg/sendmmsg syscalls follow separately.

## Why

The previous send path allocated four times per datagram: the 14-byte header, the AEAD ciphertext, the `append(header, ct...)` frame, and the nonce. At multi-gigabit rates that is steady GC pressure on the transport's hottest path. The `DatagramConn.Send` contract already reserved single-goroutine use "for the zero-alloc path", so a retained per-connection frame buffer is the intended design.

## How

- `pkg/crypto/aead_inplace.go` - `SealWithNonceTo` / `OpenWithNonceTo`: AEAD seal/open that append into a caller-supplied `dst` (Go's `cipher.AEAD` append semantics) instead of allocating, so a buffer with spare capacity is reused with zero allocations.
- `pkg/tunnel/dgram_session_inplace.go` - `DatagramSealTo` / `DatagramOpenTo`: the datagram session wrappers (epoch cipher selection, derived nonce, nonce-budget cap) over the in-place AEAD, mirroring `DatagramSeal`/`DatagramOpen`.
- `pkg/protocol/datagram_inplace.go` - `AppendDatagramDataHeader`: writes the 14-byte DATA header into a reusable buffer with no temporary (the `append(dst, make(...)...)` form the compiler special-cases), so the header and the sealed payload share one allocation-free buffer.
- `pkg/tunnel/dgram_conn.go` - `Send` builds `header || ciphertext || tag` in a retained `sendBuf` (the header doubles as the AEAD AAD; `DatagramSealTo` appends the payload after it) and keeps the grown backing array for the next call.

The allocating `DatagramSeal`/`DatagramOpen` and `EncodeDatagramHeader` are unchanged for callers without a reusable buffer (`Close`, the handshake/rekey paths). The receive path still allocates: its plaintext is handed to the application across a channel, so it cannot share one reused buffer without a pool - left for a follow-up.

## Results (go test -benchmem)

- AEAD primitive `BenchmarkSealWithNonce`: allocating 420 ns/op, 1280 B/op, 1 alloc/op -> in-place 289 ns/op, 0 B/op, 0 allocs/op.
- End-to-end `DatagramConn.Send` (through a discard conn): old path 741 ns/op, 2624 B/op, 4 allocs/op -> new path 393 ns/op (~3.0 GB/s), 16 B/op, 1 alloc/op.

The one remaining alloc per Send is the 12-byte nonce, which escapes to the heap through Go's `cipher.AEAD` interface boundary (it does so in the old `DatagramSeal` too); removing it would need a reusable nonce scratch threaded through the interface and is left out of scope.

## Tests

Round-trip and cross-check of the in-place AEAD against the allocating variants, bad-nonce and tampered-tag rejection, plus the benchmarks above. Full suite green under `-race`; golangci-lint and gofmt clean.

## Out of scope (follow-up PRs)

Batched `recvmmsg`/`sendmmsg` (adds `golang.org/x/net`, Linux build tag + portable fallback); a pooled zero-alloc receive path; dropping the residual nonce alloc.
