### PR TITLE
batch datagram receive with recvmmsg and coalesce handshake flight sends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/net v0.52.0
+	golang.org/x/sys v0.45.0
 )
 
 require (
@@ -15,5 +17,4 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/cloudflare/circl v1.6.3
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
-	golang.org/x/crypto v0.49.0
-	golang.org/x/net v0.52.0
+	golang.org/x/crypto v0.52.0
+	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,9 @@ go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4Len
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
+golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -23,10 +23,10 @@ go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUl
 go.opentelemetry.io/otel/metric v1.42.0/go.mod h1:RlUN/7vTU7Ao/diDkEpQpnz3/92J9ko05BIwxYa2SSI=
 go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4LenLmOYY=
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -173,6 +173,11 @@ const (
 	// per Send; no PMTU discovery).
 	DatagramMaxDataPayload = DatagramMTU - DatagramDataOverhead
 
+	// DatagramBatchSize is how many datagrams the receive loop reads per recvmmsg
+	// syscall on platforms that support it (Linux). It bounds the reusable
+	// per-endpoint receive buffer set (DatagramBatchSize * (DatagramMTU+512)).
+	DatagramBatchSize = 32
+
 	// DatagramNoncePrefixSize is the size of the per-session random nonce prefix.
 	// The 12-byte AEAD nonce is the prefix followed by the 8-byte sequence
 	// number, so the prefix is the AEAD nonce size minus 8.

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -304,6 +304,7 @@ func (r *connRegistry) removeSource(source string) {
 // and surfaces newly-established inbound sessions on an accept channel.
 type DatagramEndpoint struct {
 	conn     net.PacketConn
+	batch    batchIO
 	registry *connRegistry
 	reasm    *Reassembler
 	acceptCh chan *datagramSession
@@ -340,6 +341,7 @@ func NewDatagramEndpoint(conn net.PacketConn) (*DatagramEndpoint, error) {
 	}
 	return &DatagramEndpoint{
 		conn:                    conn,
+		batch:                   newBatchIO(conn),
 		registry:                newConnRegistry(),
 		reasm:                   NewReassembler(0, 0, 0),
 		acceptCh:                make(chan *datagramSession, 16),
@@ -379,15 +381,13 @@ func (e *DatagramEndpoint) Close() error {
 // goroutine (go ep.Serve()). It returns when the underlying conn is closed.
 func (e *DatagramEndpoint) Serve() {
 	go e.reapIdle()
-	buf := make([]byte, constants.DatagramMTU+512)
+	dispatch := func(src net.Addr, data []byte) {
+		_ = e.routeDatagram(src, data)
+	}
 	for {
-		n, src, err := e.conn.ReadFrom(buf)
-		if err != nil {
+		if err := e.batch.recv(dispatch); err != nil {
 			return
 		}
-		data := make([]byte, n)
-		copy(data, buf[:n])
-		_ = e.routeDatagram(src, data)
 	}
 }
 

--- a/pkg/tunnel/dgram_batch.go
+++ b/pkg/tunnel/dgram_batch.go
@@ -1,0 +1,56 @@
+package tunnel
+
+import (
+	"net"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+)
+
+// batchIO reads datagrams from and writes datagrams to the endpoint's packet
+// conn. On Linux over a *net.UDPConn it uses batched recvmmsg/sendmmsg syscalls
+// (one syscall per batch instead of per datagram); everywhere else, and whenever
+// the conn is not a *net.UDPConn (e.g. an in-memory test conn), it falls back to
+// one-at-a-time ReadFrom/WriteTo. newBatchIO is defined per-platform in
+// dgram_batch_linux.go / dgram_batch_other.go.
+type batchIO interface {
+	// recv reads one batch of datagrams and calls dispatch for each, in arrival
+	// order, with a freshly-allocated payload copy the callee may retain. It blocks
+	// until at least one datagram is available and returns the underlying read
+	// error (e.g. on close) so the receive loop can exit.
+	recv(dispatch func(src net.Addr, payload []byte)) error
+	// writeAll writes every frame to dst, best-effort: write errors are ignored,
+	// matching the single-shot send sites (handshake/rekey retransmission recovers
+	// any dropped frame). Safe for concurrent use.
+	writeAll(frames [][]byte, dst net.Addr)
+}
+
+// fallbackIO is the portable one-datagram-at-a-time implementation over the
+// net.PacketConn interface. recv is only ever driven by the single Serve
+// goroutine, so its reusable read buffer needs no synchronization; writeAll
+// touches only the conn (which is safe for concurrent WriteTo), so it is safe to
+// call from many goroutines alongside recv.
+type fallbackIO struct {
+	conn net.PacketConn
+	buf  []byte
+}
+
+func newFallbackIO(conn net.PacketConn) *fallbackIO {
+	return &fallbackIO{conn: conn, buf: make([]byte, constants.DatagramMTU+512)}
+}
+
+func (f *fallbackIO) recv(dispatch func(src net.Addr, payload []byte)) error {
+	n, src, err := f.conn.ReadFrom(f.buf)
+	if err != nil {
+		return err
+	}
+	data := make([]byte, n)
+	copy(data, f.buf[:n])
+	dispatch(src, data)
+	return nil
+}
+
+func (f *fallbackIO) writeAll(frames [][]byte, dst net.Addr) {
+	for _, fr := range frames {
+		_, _ = f.conn.WriteTo(fr, dst)
+	}
+}

--- a/pkg/tunnel/dgram_batch_linux.go
+++ b/pkg/tunnel/dgram_batch_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package tunnel
+
+import (
+	"net"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/sys/unix"
+)
+
+// newBatchIO returns a recvmmsg/sendmmsg-backed batchIO when conn is a
+// *net.UDPConn, else the portable single-datagram fallback (e.g. an in-memory
+// test conn). ipv4.PacketConn is used for both address families: we read only the
+// payload and source address (no control messages), which recvmmsg handles
+// regardless of whether the socket is v4 or v6.
+func newBatchIO(conn net.PacketConn) batchIO {
+	udp, ok := conn.(*net.UDPConn)
+	if !ok {
+		return newFallbackIO(conn)
+	}
+	pc := ipv4.NewPacketConn(udp)
+	rmsgs := make([]ipv4.Message, constants.DatagramBatchSize)
+	for i := range rmsgs {
+		rmsgs[i].Buffers = [][]byte{make([]byte, constants.DatagramMTU+512)}
+	}
+	return &linuxBatchIO{pc: pc, rmsgs: rmsgs}
+}
+
+type linuxBatchIO struct {
+	pc *ipv4.PacketConn
+	// rmsgs holds the reusable receive buffers. It is owned exclusively by the
+	// single Serve/recv goroutine, so it needs no synchronization.
+	rmsgs []ipv4.Message
+}
+
+func (b *linuxBatchIO) recv(dispatch func(src net.Addr, payload []byte)) error {
+	// MSG_WAITFORONE makes recvmmsg return as soon as the first datagram is
+	// available (draining any others already queued) instead of blocking until the
+	// whole batch fills, matching ReadFrom's "block for one, return promptly"
+	// latency. Without it, recvmmsg with a NULL timeout waits for the full batch.
+	n, err := b.pc.ReadBatch(b.rmsgs, unix.MSG_WAITFORONE)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < n; i++ {
+		m := &b.rmsgs[i]
+		// Copy out before the next ReadBatch overwrites the shared buffer; the
+		// payload is routed onward (reassembly / recvCh) and outlives this call.
+		data := make([]byte, m.N)
+		copy(data, m.Buffers[0][:m.N])
+		dispatch(m.Addr, data)
+	}
+	return nil
+}
+
+func (b *linuxBatchIO) writeAll(frames [][]byte, dst net.Addr) {
+	if len(frames) == 0 {
+		return
+	}
+	// Fresh message slice per call: writeAll is called concurrently from multiple
+	// goroutines, so a shared reusable slice would race. Flights are infrequent, so
+	// this small allocation is irrelevant.
+	msgs := make([]ipv4.Message, len(frames))
+	for i, fr := range frames {
+		msgs[i].Buffers = [][]byte{fr}
+		msgs[i].Addr = dst
+	}
+	// Best-effort, matching the WriteTo sites; a short or failed write is recovered
+	// by handshake/rekey retransmission.
+	_, _ = b.pc.WriteBatch(msgs, 0)
+}

--- a/pkg/tunnel/dgram_batch_linux_test.go
+++ b/pkg/tunnel/dgram_batch_linux_test.go
@@ -18,12 +18,12 @@ func TestLinuxBatchIORecvLoopback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen rx: %v", err)
 	}
-	defer rx.Close()
+	defer func() { _ = rx.Close() }()
 	tx, err := net.DialUDP("udp", nil, rx.LocalAddr().(*net.UDPAddr))
 	if err != nil {
 		t.Fatalf("dial tx: %v", err)
 	}
-	defer tx.Close()
+	defer func() { _ = tx.Close() }()
 
 	bio := newBatchIO(rx)
 	if _, ok := bio.(*linuxBatchIO); !ok {
@@ -73,12 +73,12 @@ func BenchmarkDatagramRecvBatch(b *testing.B) {
 	if err != nil {
 		b.Fatalf("listen: %v", err)
 	}
-	defer rx.Close()
+	defer func() { _ = rx.Close() }()
 	tx, err := net.DialUDP("udp", nil, rx.LocalAddr().(*net.UDPAddr))
 	if err != nil {
 		b.Fatalf("dial: %v", err)
 	}
-	defer tx.Close()
+	defer func() { _ = tx.Close() }()
 
 	payload := make([]byte, 1200)
 	stop := make(chan struct{})

--- a/pkg/tunnel/dgram_batch_linux_test.go
+++ b/pkg/tunnel/dgram_batch_linux_test.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+package tunnel
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestLinuxBatchIORecvLoopback exercises the real recvmmsg/WriteBatch path over a
+// loopback *net.UDPConn: several datagrams sent are all received and handed to the
+// dispatch callback. It runs only on Linux, where newBatchIO returns the
+// x/net-backed implementation for a *net.UDPConn.
+func TestLinuxBatchIORecvLoopback(t *testing.T) {
+	rx, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen rx: %v", err)
+	}
+	defer rx.Close()
+	tx, err := net.DialUDP("udp", nil, rx.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatalf("dial tx: %v", err)
+	}
+	defer tx.Close()
+
+	bio := newBatchIO(rx)
+	if _, ok := bio.(*linuxBatchIO); !ok {
+		t.Fatalf("newBatchIO over *net.UDPConn = %T, want *linuxBatchIO", bio)
+	}
+
+	want := [][]byte{[]byte("one"), []byte("two"), []byte("three"), []byte("four")}
+	for _, d := range want {
+		if _, err := tx.Write(d); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Bound the wait so a lost datagram fails fast instead of hanging; loopback
+	// does not drop these few.
+	_ = rx.SetReadDeadline(time.Now().Add(2 * time.Second))
+	got := make([][]byte, 0, len(want))
+	for len(got) < len(want) {
+		if err := bio.recv(func(_ net.Addr, payload []byte) {
+			got = append(got, payload)
+		}); err != nil {
+			t.Fatalf("recv after %d/%d datagrams: %v", len(got), len(want), err)
+		}
+	}
+
+	for _, w := range want {
+		if !containsBytes(got, w) {
+			t.Errorf("datagram %q not received (got %d datagrams)", w, len(got))
+		}
+	}
+}
+
+func containsBytes(set [][]byte, want []byte) bool {
+	for _, b := range set {
+		if bytes.Equal(b, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// BenchmarkDatagramRecvBatch measures loopback receive throughput through the
+// batched path (run with -benchmem). A background goroutine floods the socket so
+// recv always has data to drain.
+func BenchmarkDatagramRecvBatch(b *testing.B) {
+	rx, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		b.Fatalf("listen: %v", err)
+	}
+	defer rx.Close()
+	tx, err := net.DialUDP("udp", nil, rx.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		b.Fatalf("dial: %v", err)
+	}
+	defer tx.Close()
+
+	payload := make([]byte, 1200)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = tx.Write(payload)
+			}
+		}
+	}()
+
+	bio := newBatchIO(rx)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	received := 0
+	for received < b.N {
+		if err := bio.recv(func(_ net.Addr, _ []byte) { received++ }); err != nil {
+			b.Fatalf("recv: %v", err)
+		}
+	}
+	b.StopTimer()
+	close(stop)
+}

--- a/pkg/tunnel/dgram_batch_other.go
+++ b/pkg/tunnel/dgram_batch_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package tunnel
+
+import "net"
+
+// newBatchIO returns the portable single-datagram fallback on platforms without
+// recvmmsg/sendmmsg support. It does not import golang.org/x/net.
+func newBatchIO(conn net.PacketConn) batchIO {
+	return newFallbackIO(conn)
+}

--- a/pkg/tunnel/dgram_batch_test.go
+++ b/pkg/tunnel/dgram_batch_test.go
@@ -1,0 +1,132 @@
+package tunnel
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// scriptedConn is a net.PacketConn for exercising the portable fallbackIO path.
+// ReadFrom returns each queued datagram once, then net.ErrClosed (so a recv loop
+// terminates); WriteTo records every write. Because it is not a *net.UDPConn,
+// newBatchIO returns the fallback on every platform, so this covers the fallback
+// uniformly in CI.
+type scriptedConn struct {
+	mu      sync.Mutex
+	reads   []scriptedPkt
+	readIdx int
+	writes  []scriptedPkt
+}
+
+type scriptedPkt struct {
+	data []byte
+	addr net.Addr
+}
+
+func (c *scriptedConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.readIdx >= len(c.reads) {
+		return 0, nil, net.ErrClosed
+	}
+	pkt := c.reads[c.readIdx]
+	c.readIdx++
+	n := copy(p, pkt.data)
+	return n, pkt.addr, nil
+}
+
+func (c *scriptedConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes = append(c.writes, scriptedPkt{data: append([]byte(nil), p...), addr: addr})
+	return len(p), nil
+}
+
+func (c *scriptedConn) Close() error                     { return nil }
+func (c *scriptedConn) LocalAddr() net.Addr              { return &net.UDPAddr{} }
+func (c *scriptedConn) SetDeadline(time.Time) error      { return nil }
+func (c *scriptedConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *scriptedConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestFallbackIORecvDispatchesEachDatagram(t *testing.T) {
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234}
+	want := [][]byte{[]byte("alpha"), []byte("bravo"), []byte("charlie")}
+	conn := &scriptedConn{}
+	for _, d := range want {
+		conn.reads = append(conn.reads, scriptedPkt{data: d, addr: addr})
+	}
+
+	bio := newBatchIO(conn)
+	var got [][]byte
+	for {
+		err := bio.recv(func(src net.Addr, payload []byte) {
+			if src != addr {
+				t.Errorf("src = %v, want %v", src, addr)
+			}
+			got = append(got, payload)
+		})
+		if err != nil {
+			break
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("dispatched %d datagrams, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("datagram %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFallbackIORecvCopiesPayload(t *testing.T) {
+	// recv must hand the callee a copy that survives the reuse of the read buffer
+	// on the following recv.
+	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}
+	conn := &scriptedConn{reads: []scriptedPkt{
+		{data: []byte("first"), addr: addr},
+		{data: []byte("SECOND-and-longer"), addr: addr},
+	}}
+
+	bio := newBatchIO(conn)
+	var retained []byte
+	_ = bio.recv(func(_ net.Addr, payload []byte) { retained = payload })
+	_ = bio.recv(func(_ net.Addr, _ []byte) {})
+
+	if !bytes.Equal(retained, []byte("first")) {
+		t.Fatalf("retained payload corrupted by a later recv: %q", retained)
+	}
+}
+
+func TestWriteAllEmitsEachFrameToDst(t *testing.T) {
+	dst := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9999}
+	frames := [][]byte{[]byte("f0"), []byte("f1"), []byte("f2")}
+	conn := &scriptedConn{}
+
+	bio := newBatchIO(conn)
+	bio.writeAll(frames, dst)
+
+	if len(conn.writes) != len(frames) {
+		t.Fatalf("wrote %d datagrams, want %d", len(conn.writes), len(frames))
+	}
+	for i, w := range conn.writes {
+		if !bytes.Equal(w.data, frames[i]) {
+			t.Errorf("frame %d = %q, want %q", i, w.data, frames[i])
+		}
+		if w.addr != dst {
+			t.Errorf("frame %d addr = %v, want %v", i, w.addr, dst)
+		}
+	}
+}
+
+func TestWriteAllEmptyEmitsNothing(t *testing.T) {
+	conn := &scriptedConn{}
+	bio := newBatchIO(conn)
+	bio.writeAll(nil, &net.UDPAddr{})
+	if len(conn.writes) != 0 {
+		t.Fatalf("empty writeAll emitted %d datagrams", len(conn.writes))
+	}
+}

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -293,9 +293,7 @@ func (l *handshakeLoop) send(msgs []hsMessage) {
 		if err != nil {
 			return
 		}
-		for _, f := range frames {
-			_, _ = l.ep.conn.WriteTo(f, l.src)
-		}
+		l.ep.batch.writeAll(frames, l.src)
 		l.seq += uint64(len(frames))
 	}
 }

--- a/pkg/tunnel/dgram_rekey.go
+++ b/pkg/tunnel/dgram_rekey.go
@@ -241,9 +241,7 @@ func (c *DatagramConn) Rekey() error {
 				return errRekeyTimeout
 			}
 			peer := c.ds.currentPeerAddr() // re-read so a mid-rekey roam is followed
-			for _, f := range frames {
-				_, _ = c.ep.conn.WriteTo(f, peer)
-			}
+			c.ep.batch.writeAll(frames, peer)
 			attempts++
 			armTimer(timer, rto)
 			if rto *= 2; rto > c.ep.rtoMax {
@@ -293,9 +291,7 @@ func (e *DatagramEndpoint) handleRekeyInit(ds *datagramSession, epoch uint8, bod
 
 	if ds.rekeyRespValid && ds.rekeyRespFrom == epoch {
 		peer := ds.currentPeerAddr()
-		for _, f := range ds.rekeyRespFrames {
-			_, _ = e.conn.WriteTo(f, peer)
-		}
+		e.batch.writeAll(ds.rekeyRespFrames, peer)
 		return
 	}
 	// Only a rekey transitioning from the current epoch is processed; stale or
@@ -315,7 +311,5 @@ func (e *DatagramEndpoint) handleRekeyInit(ds *datagramSession, epoch uint8, bod
 	ds.rekeyRespFrames = frames
 	ds.rekeyRespValid = true
 	peer := ds.currentPeerAddr()
-	for _, f := range frames {
-		_, _ = e.conn.WriteTo(f, peer)
-	}
+	e.batch.writeAll(frames, peer)
 }


### PR DESCRIPTION
## What

Batches the datagram receive loop with `recvmmsg` on Linux (one syscall drains up to 32 datagrams instead of one `ReadFrom` per datagram), and coalesces the multi-frame handshake/rekey flight sends into a single `sendmmsg`. Adds the `batchIO` abstraction behind it with a portable single-datagram fallback. The data-plane single-shot `Send` is untouched.

## Why

A datagram server demultiplexes many sessions over one socket, so its receive loop reads every peer's traffic. One `ReadFrom` syscall per datagram is the dominant per-packet cost there at scale; `recvmmsg` amortizes it across a batch. The handshake and rekey paths already build several frames in one goroutine and sent them with a `WriteTo` loop, so they fold into one `WriteBatch` for free.

This is the receive-side ("big win") half of the batched-I/O work. A full TX coalescing queue for the data plane (data-plane `sendmmsg`) is deliberately out of scope: it needs a flush goroutine and a per-packet batching latency for a marginal gain over the merged zero-alloc single-shot `Send`, and is left for a future PR.

## How

- `pkg/tunnel/dgram_batch.go` (portable) - the `batchIO` interface (`recv` dispatches each received datagram to a callback; `writeAll` writes a set of frames to one destination) plus `fallbackIO`, the one-datagram-at-a-time implementation over the `net.PacketConn` interface (the previous behavior, byte for byte).
- `pkg/tunnel/dgram_batch_linux.go` (`//go:build linux`) - the `recvmmsg`/`sendmmsg`-backed implementation over a `*net.UDPConn` via `golang.org/x/net/ipv4`. `recv` uses `ReadBatch` with `MSG_WAITFORONE` so it returns as soon as the first datagram is available (draining any others already queued) rather than blocking until the whole batch fills. `writeAll` issues one `WriteBatch`. When the conn is not a `*net.UDPConn` (e.g. an in-memory test conn), it returns the portable fallback.
- `pkg/tunnel/dgram_batch_other.go` (`//go:build !linux`) - returns the portable fallback unconditionally and does not import `golang.org/x/net`.
- `pkg/tunnel/datagram.go` - the endpoint holds one `batchIO` (built in `NewDatagramEndpoint`); `Serve` drives `recv` in a loop.
- `pkg/tunnel/dgram_handshake_wire.go`, `pkg/tunnel/dgram_rekey.go` - the four handshake/rekey frame loops now call `writeAll`.

The endpoint socket is unconnected (`net.ListenPacket` on both sides; the data plane already does `WriteTo(frame, currentPeerAddr())`), so the per-message destination on `WriteBatch` is correct. `writeAll` builds a fresh message slice per call because it is called concurrently from multiple goroutines; flights are infrequent, so that small allocation is irrelevant. `recv` copies each datagram out of the reused batch buffer before dispatch, since the payload is routed onward and outlives the call (the receive path's per-datagram copy is unchanged from before; a pooled zero-copy receive path is a separate follow-up).

## Dependencies

Adds `golang.org/x/net` as a direct dependency (it provides the batch API) and bumps `golang.org/x/sys`, which it requires. `golang.org/x/crypto` is unchanged.

## Tests

- `pkg/tunnel/dgram_batch_test.go` - the portable fallback over a scripted conn (which is what the in-memory test conns exercise on every platform, including Linux, since they are not `*net.UDPConn`): `recv` dispatches each datagram in order, `recv` hands the callee a copy that survives the next read, `writeAll` emits each frame to the destination, empty `writeAll` emits nothing.
- `pkg/tunnel/dgram_batch_linux_test.go` (`//go:build linux`) - the real `recvmmsg`/`WriteBatch` path over a loopback `*net.UDPConn`, plus `BenchmarkDatagramRecvBatch`.
- The existing handshake/rekey e2e tests run over the in-memory conn and continue to cover the `writeAll` fallback end to end.