### PR TITLE
add optional fixed-size handshake padding

### DIFF
--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -121,6 +121,22 @@ gap and enforces a strict anti-amplification bound, and a session follows a
 roaming peer only on an authenticated, replay-fresh frame; see
 [datagram-dos.md](datagram-dos.md).
 
+### Optional handshake padding (anti-fingerprinting)
+
+`WithHandshakePadding()` zero-pads every handshake and rekey datagram to the MTU,
+so ClientHello, ServerHello, and the rekey sub-handshake are size-indistinguishable
+on the wire, defeating passive size-based traffic analysis of "a CH-KEM handshake is
+happening here." It is off by default (it costs bandwidth) and never pads the data
+plane. The padding rides after the fragment payload and outside the declared
+fragment length, so the receiver slices it off before reassembly: it never enters
+the reassembled message or the handshake transcript, cannot smuggle bytes into the
+authenticated handshake, and does not change per-source reassembly memory (sized by
+the declared total length, not the datagram size). It also cannot weaken the
+anti-amplification bound, since a RETRY is only ever sent when it is no larger than
+the triggering datagram. The receiver tolerates padding unconditionally, so a
+padding peer interoperates with a non-padding one; for full effect enable it on both
+ends.
+
 ## Out of scope (future)
 
 GSO/GRO offload, PMTU discovery, multipath, and a parallel per-datagram crypto

--- a/pkg/protocol/datagram_codec.go
+++ b/pkg/protocol/datagram_codec.go
@@ -224,11 +224,14 @@ func ParseDatagramHandshake(data []byte) (DatagramHandshakeHeader, []byte, error
 		off += cookieLen
 	}
 	fragment := data[off:]
-	// FragLength must describe exactly the fragment bytes present, and the
-	// fragment must fit within the declared total message length.
-	if int(h.FragLength) != len(fragment) {
+	// The bytes present must cover at least FragLength; any extra trailing bytes
+	// are optional anti-fingerprinting padding (see tunnel.fragmentHandshake) and
+	// are sliced off here, so neither reassembly nor the handshake transcript ever
+	// sees them. An unpadded frame has len(fragment) == FragLength and is unchanged.
+	if len(fragment) < int(h.FragLength) {
 		return DatagramHandshakeHeader{}, nil, qerrors.ErrInvalidMessage
 	}
+	fragment = fragment[:h.FragLength]
 	if int(h.FragOffset)+int(h.FragLength) > int(h.TotalLength) {
 		return DatagramHandshakeHeader{}, nil, qerrors.ErrInvalidMessage
 	}

--- a/pkg/protocol/datagram_padding_test.go
+++ b/pkg/protocol/datagram_padding_test.go
@@ -1,0 +1,68 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestParseDatagramHandshake_TrailingPadding verifies the parser accepts a frame
+// carrying trailing padding after the fragment payload (optional
+// anti-fingerprinting padding) and returns exactly the unpadded fragment, leaving
+// the padding out of the reassembled message and the handshake transcript.
+func TestParseDatagramHandshake_TrailingPadding(t *testing.T) {
+	frag := []byte("fragment-payload")
+	h := DatagramHandshakeHeader{
+		DatagramHeader: DatagramHeader{Seq: 9},
+		SenderIndex:    0xAABBCCDD,
+		MsgType:        MessageTypeClientHello,
+		FragLength:     uint16(len(frag)),
+		TotalLength:    uint16(len(frag)),
+	}
+	frame, err := EncodeDatagramHandshake(h, frag)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// Append trailing zero padding, as fragmentHandshake does when padding is on.
+	padded := append(append([]byte(nil), frame...), make([]byte, 64)...)
+
+	gotH, gotFrag, err := ParseDatagramHandshake(padded)
+	if err != nil {
+		t.Fatalf("parse padded frame: %v", err)
+	}
+	if gotH.FragLength != h.FragLength || gotH.TotalLength != h.TotalLength {
+		t.Fatalf("length fields changed by padding: got frag=%d total=%d", gotH.FragLength, gotH.TotalLength)
+	}
+	if !bytes.Equal(gotFrag, frag) {
+		t.Fatalf("padded fragment not sliced to FragLength: got %q want %q", gotFrag, frag)
+	}
+
+	// An unpadded frame must still parse identically (backward compatible).
+	gotH2, gotFrag2, err := ParseDatagramHandshake(frame)
+	if err != nil {
+		t.Fatalf("parse unpadded frame: %v", err)
+	}
+	if !bytes.Equal(gotFrag2, frag) || gotH2.FragLength != h.FragLength {
+		t.Fatal("unpadded frame did not round-trip unchanged")
+	}
+}
+
+// TestParseDatagramHandshake_RejectsUnderrun verifies a frame whose present bytes
+// are fewer than FragLength claims is still rejected (padding tolerance only
+// accepts EXTRA trailing bytes, never a short fragment).
+func TestParseDatagramHandshake_RejectsUnderrun(t *testing.T) {
+	frag := []byte("0123456789")
+	h := DatagramHandshakeHeader{
+		MsgType:     MessageTypeClientHello,
+		FragLength:  uint16(len(frag)),
+		TotalLength: uint16(len(frag)),
+	}
+	frame, err := EncodeDatagramHandshake(h, frag)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Drop the last 3 fragment bytes so present bytes < FragLength.
+	if _, _, err := ParseDatagramHandshake(frame[:len(frame)-3]); err == nil {
+		t.Fatal("expected rejection when present bytes are fewer than FragLength")
+	}
+}

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -325,20 +325,39 @@ type DatagramEndpoint struct {
 	// tears it down; defaulted from constants, overridable for fast tests.
 	idleTimeout time.Duration
 
+	// padHandshake, when set, zero-pads every outbound handshake and rekey datagram
+	// to DatagramMTU so the flight is uniform-size on the wire (anti-fingerprinting).
+	// Off by default (it costs bandwidth); set via WithHandshakePadding. The receiver
+	// always tolerates padding regardless of this flag, so a padding peer interops
+	// with a non-padding one; full hiding needs both ends to enable it.
+	padHandshake bool
+
 	closeOnce sync.Once
 	done      chan struct{}
+}
+
+// DatagramEndpointOption configures a DatagramEndpoint at construction.
+type DatagramEndpointOption func(*DatagramEndpoint)
+
+// WithHandshakePadding pads every outbound handshake and rekey datagram to the
+// datagram MTU, so ClientHello, ServerHello, and the rekey sub-handshake are all
+// size-indistinguishable on the wire. It trades bandwidth for resistance to
+// passive size-based traffic analysis; the data plane is never padded. For full
+// effect both peers should enable it.
+func WithHandshakePadding() DatagramEndpointOption {
+	return func(e *DatagramEndpoint) { e.padHandshake = true }
 }
 
 // NewDatagramEndpoint wraps a PacketConn (a *net.UDPConn in production, or a
 // fault-injecting conn in tests). It does not start the receive loop; callers
 // start it explicitly so tests can drive routing deterministically. It returns an
 // error only if the per-endpoint cookie secret cannot be drawn from the CSPRNG.
-func NewDatagramEndpoint(conn net.PacketConn) (*DatagramEndpoint, error) {
+func NewDatagramEndpoint(conn net.PacketConn, opts ...DatagramEndpointOption) (*DatagramEndpoint, error) {
 	cookie, err := newCookieSigner(nil)
 	if err != nil {
 		return nil, err
 	}
-	return &DatagramEndpoint{
+	e := &DatagramEndpoint{
 		conn:                    conn,
 		registry:                newConnRegistry(),
 		reasm:                   NewReassembler(0, 0, 0),
@@ -349,7 +368,11 @@ func NewDatagramEndpoint(conn net.PacketConn) (*DatagramEndpoint, error) {
 		rtoMax:                  time.Duration(constants.DatagramHandshakeMaxTimeoutMillis) * time.Millisecond,
 		idleTimeout:             time.Duration(constants.DatagramIdleTimeoutSeconds) * time.Second,
 		done:                    make(chan struct{}),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e, nil
 }
 
 // underCookiePressure reports whether the endpoint should demand a

--- a/pkg/tunnel/dgram_handshake.go
+++ b/pkg/tunnel/dgram_handshake.go
@@ -28,7 +28,13 @@ func maxHandshakeFragmentPayload(cookieLen int) int {
 // TotalLength per fragment and assigns each frame a distinct, increasing
 // sequence number starting at base.Seq. The frames reassemble in any order on
 // the peer.
-func fragmentHandshake(base protocol.DatagramHandshakeHeader, msg []byte) ([][]byte, error) {
+//
+// When pad is set, each frame is zero-extended to exactly DatagramMTU. The
+// padding sits after the fragment payload and is excluded from FragLength, so the
+// receiver's parser slices it off before reassembly - it never enters the message
+// or the handshake transcript. This makes every handshake datagram uniform-size
+// (anti-fingerprinting); it does not equalize the number of datagrams per flight.
+func fragmentHandshake(base protocol.DatagramHandshakeHeader, msg []byte, pad bool) ([][]byte, error) {
 	total := len(msg)
 	if total == 0 || total > constants.DatagramMaxHandshakeMessageSize {
 		return nil, qerrors.ErrMessageTooLarge
@@ -53,6 +59,9 @@ func fragmentHandshake(base protocol.DatagramHandshakeHeader, msg []byte) ([][]b
 		frame, err := protocol.EncodeDatagramHandshake(h, msg[off:end])
 		if err != nil {
 			return nil, err
+		}
+		if pad && len(frame) < constants.DatagramMTU {
+			frame = append(frame, make([]byte, constants.DatagramMTU-len(frame))...)
 		}
 		frames = append(frames, frame)
 		seq++

--- a/pkg/tunnel/dgram_handshake_test.go
+++ b/pkg/tunnel/dgram_handshake_test.go
@@ -21,7 +21,7 @@ func TestFragmentHandshake_RoundTrip(t *testing.T) {
 		MsgType:        protocol.MessageTypeClientHello,
 	}
 
-	frames, err := fragmentHandshake(base, msg)
+	frames, err := fragmentHandshake(base, msg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestFragmentHandshake_RoundTrip(t *testing.T) {
 
 func TestFragmentHandshake_SingleFragment(t *testing.T) {
 	base := protocol.DatagramHandshakeHeader{MsgType: protocol.MessageTypeClientHello}
-	frames, err := fragmentHandshake(base, []byte("short message"))
+	frames, err := fragmentHandshake(base, []byte("short message"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,11 +67,11 @@ func TestFragmentHandshake_SingleFragment(t *testing.T) {
 
 func TestFragmentHandshake_RejectsEmptyAndOversize(t *testing.T) {
 	base := protocol.DatagramHandshakeHeader{MsgType: protocol.MessageTypeClientHello}
-	if _, err := fragmentHandshake(base, nil); err == nil {
+	if _, err := fragmentHandshake(base, nil, false); err == nil {
 		t.Fatal("an empty message must be rejected")
 	}
 	big := make([]byte, constants.DatagramMaxHandshakeMessageSize+1)
-	if _, err := fragmentHandshake(base, big); err == nil {
+	if _, err := fragmentHandshake(base, big, false); err == nil {
 		t.Fatal("an oversize message must be rejected")
 	}
 }

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -289,7 +289,7 @@ func (l *handshakeLoop) send(msgs []hsMessage) {
 		if m.typ == protocol.MessageTypeClientHello {
 			base.Cookie = l.cookie
 		}
-		frames, err := fragmentHandshake(base, m.body)
+		frames, err := fragmentHandshake(base, m.body, l.ep.padHandshake)
 		if err != nil {
 			return
 		}

--- a/pkg/tunnel/dgram_padding_test.go
+++ b/pkg/tunnel/dgram_padding_test.go
@@ -1,0 +1,172 @@
+package tunnel
+
+import (
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// TestFragmentHandshake_PaddingUniformSize asserts that with padding on every
+// frame is exactly DatagramMTU, with padding off no frame is padded, and that a
+// padded flight still reassembles to the identical original message (the padding
+// is sliced off by the parser before reassembly).
+func TestFragmentHandshake_PaddingUniformSize(t *testing.T) {
+	msg := make([]byte, 1644) // spans two datagrams
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	base := protocol.DatagramHandshakeHeader{
+		DatagramHeader: protocol.DatagramHeader{RecvIndex: 7, Seq: 100},
+		SenderIndex:    42,
+		MsgType:        protocol.MessageTypeClientHello,
+	}
+
+	padded, err := fragmentHandshake(base, msg, true)
+	if err != nil {
+		t.Fatalf("padded fragment: %v", err)
+	}
+	if len(padded) < 2 {
+		t.Fatalf("expected multiple fragments, got %d", len(padded))
+	}
+	for i, f := range padded {
+		if len(f) != constants.DatagramMTU {
+			t.Fatalf("padded frame %d is %d bytes, want exactly MTU %d", i, len(f), constants.DatagramMTU)
+		}
+	}
+
+	plain, err := fragmentHandshake(base, msg, false)
+	if err != nil {
+		t.Fatalf("unpadded fragment: %v", err)
+	}
+	// At least one frame (the last, short one) must be below MTU when not padded.
+	allMTU := true
+	for _, f := range plain {
+		if len(f) != constants.DatagramMTU {
+			allMTU = false
+		}
+	}
+	if allMTU {
+		t.Fatal("unpadded frames should not all be MTU-sized")
+	}
+
+	// A padded flight reassembles to the identical original.
+	r := NewReassembler(4, 8192, time.Second)
+	var out []byte
+	var done bool
+	for i, f := range padded {
+		h, frag, perr := protocol.ParseDatagramHandshake(f)
+		if perr != nil {
+			t.Fatalf("frame %d parse: %v", i, perr)
+		}
+		out, done, err = r.Add("peer", h, frag)
+		if err != nil {
+			t.Fatalf("frame %d reassemble: %v", i, err)
+		}
+	}
+	if !done || !bytes.Equal(out, msg) {
+		t.Fatal("padded flight did not reassemble to the original message")
+	}
+}
+
+// recordingConn wraps a net.PacketConn and records the size and frame type of
+// every datagram written, so a test can assert handshake datagrams are padded to
+// the MTU while data datagrams are not.
+type recordingConn struct {
+	net.PacketConn
+	mu          sync.Mutex
+	handshakeSz []int
+}
+
+func (c *recordingConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	if typ, err := protocol.PeekDatagramType(p); err == nil && typ == protocol.DatagramFrameHandshake {
+		c.mu.Lock()
+		c.handshakeSz = append(c.handshakeSz, len(p))
+		c.mu.Unlock()
+	}
+	return c.PacketConn.WriteTo(p, addr)
+}
+
+func (c *recordingConn) sizes() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.handshakeSz...)
+}
+
+// TestDgramHandshakePaddingE2E runs a full handshake with both ends padding, over
+// a lossless in-memory pipe, and asserts the handshake completes, data flows both
+// ways, and every handshake datagram either side emitted was exactly DatagramMTU.
+func TestDgramHandshakePaddingE2E(t *testing.T) {
+	connA, connB := memPipe(1, 0, 0, 0) // lossless: deterministic size assertions
+	recA := &recordingConn{PacketConn: connA}
+	recB := &recordingConn{PacketConn: connB}
+
+	epA, err := NewDatagramEndpoint(recA, WithHandshakePadding())
+	if err != nil {
+		t.Fatalf("endpoint A: %v", err)
+	}
+	epB, err := NewDatagramEndpoint(recB, WithHandshakePadding())
+	if err != nil {
+		t.Fatalf("endpoint B: %v", err)
+	}
+	for _, ep := range []*DatagramEndpoint{epA, epB} {
+		ep.rtoInitial = 2 * time.Millisecond
+		ep.rtoMax = 20 * time.Millisecond
+	}
+	go epA.Serve()
+	go epB.Serve()
+	defer func() { _ = epA.Close() }()
+	defer func() { _ = epB.Close() }()
+
+	type dialResult struct {
+		conn *DatagramConn
+		err  error
+	}
+	dialCh := make(chan dialResult, 1)
+	go func() {
+		c, err := DialDatagram(epA, connB.addr)
+		dialCh <- dialResult{c, err}
+	}()
+
+	var server *Session
+	select {
+	case ds := <-epB.acceptCh:
+		server = ds.session
+	case <-time.After(5 * time.Second):
+		t.Fatal("responder did not surface a session")
+	}
+
+	var client *Session
+	select {
+	case r := <-dialCh:
+		if r.err != nil {
+			t.Fatalf("dial: %v", r.err)
+		}
+		client = r.conn.Session()
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not complete")
+	}
+
+	if client.State() != SessionStateEstablished || server.State() != SessionStateEstablished {
+		t.Fatalf("not established: client=%v server=%v", client.State(), server.State())
+	}
+	assertDataRoundTrip(t, client, server)
+	assertDataRoundTrip(t, server, client)
+
+	// Every handshake datagram both ends sent must be padded to the MTU.
+	for _, rec := range []*recordingConn{recA, recB} {
+		sizes := rec.sizes()
+		if len(sizes) == 0 {
+			t.Fatal("no handshake datagrams recorded")
+		}
+		for i, sz := range sizes {
+			if sz != constants.DatagramMTU {
+				t.Fatalf("handshake datagram %d is %d bytes, want padded MTU %d", i, sz, constants.DatagramMTU)
+			}
+		}
+	}
+}

--- a/pkg/tunnel/dgram_rekey.go
+++ b/pkg/tunnel/dgram_rekey.go
@@ -180,8 +180,10 @@ func (s *Session) completeDatagramRekey(epoch uint8, respBody []byte, kp *chkem.
 // fragmentRekey splits a rekey control body into datagram HANDSHAKE frames carrying
 // the rekey message type and the sealing epoch. The reassembler keys fragments by
 // (SenderIndex, MsgType), independent of the handshake, so rekey and handshake
-// reassembly never collide.
-func fragmentRekey(ds *datagramSession, epoch uint8, msgType protocol.MessageType, body []byte) ([][]byte, error) {
+// reassembly never collide. pad applies the same uniform-size padding as the
+// handshake (rekey is the same PQ sub-handshake mid-session, so it has the same
+// size fingerprint).
+func fragmentRekey(ds *datagramSession, epoch uint8, msgType protocol.MessageType, body []byte, pad bool) ([][]byte, error) {
 	base := protocol.DatagramHandshakeHeader{
 		DatagramHeader: protocol.DatagramHeader{
 			Type:      protocol.DatagramFrameHandshake,
@@ -191,7 +193,7 @@ func fragmentRekey(ds *datagramSession, epoch uint8, msgType protocol.MessageTyp
 		SenderIndex: ds.index,
 		MsgType:     msgType,
 	}
-	return fragmentHandshake(base, body)
+	return fragmentHandshake(base, body, pad)
 }
 
 // --- initiator driver ---
@@ -219,7 +221,7 @@ func (c *DatagramConn) Rekey() error {
 	if err != nil {
 		return err
 	}
-	frames, err := fragmentRekey(c.ds, epoch, protocol.MessageTypeDatagramRekeyInit, body)
+	frames, err := fragmentRekey(c.ds, epoch, protocol.MessageTypeDatagramRekeyInit, body, c.ep.padHandshake)
 	if err != nil {
 		return err
 	}
@@ -307,7 +309,7 @@ func (e *DatagramEndpoint) handleRekeyInit(ds *datagramSession, epoch uint8, bod
 	if err != nil {
 		return
 	}
-	frames, err := fragmentRekey(ds, respEpoch, protocol.MessageTypeDatagramRekeyResponse, respBody)
+	frames, err := fragmentRekey(ds, respEpoch, protocol.MessageTypeDatagramRekeyResponse, respBody, e.padHandshake)
 	if err != nil {
 		return
 	}

--- a/test/fuzz/datagram_fuzz_test.go
+++ b/test/fuzz/datagram_fuzz_test.go
@@ -42,6 +42,7 @@ func FuzzParseDatagramHandshake(f *testing.F) {
 		Cookie:      []byte("a-cookie"),
 	}, []byte("hello"))
 	f.Add(seed)
+	f.Add(append(append([]byte(nil), seed...), make([]byte, 32)...)) // trailing padding
 	f.Add([]byte{0x01})
 	f.Add([]byte(nil))
 


### PR DESCRIPTION
## What

Adds an optional, off-by-default mode that zero-pads every datagram handshake and rekey frame to the MTU, so the post-quantum handshake is size-indistinguishable on the wire. Enable it with `NewDatagramEndpoint(conn, tunnel.WithHandshakePadding())`.

## Why

Datagram handshake messages have message-dependent sizes: ClientHello and ServerHello are two fragments of ~1200 and ~480 bytes, the Finished messages are ~53 bytes, and the rekey sub-handshake repeats that shape mid-session. That pattern is a passive traffic-analysis fingerprint that a CH-KEM handshake is happening on a flow, even though the contents are encrypted. Padding every handshake datagram to a uniform MTU removes the size signal. It costs bandwidth, so it is opt-in; the data plane is never padded.

## How

- `pkg/protocol/datagram_codec.go` - `ParseDatagramHandshake` now tolerates trailing bytes after the fragment payload: it requires the present bytes to cover at least `FragLength` and slices the fragment to exactly `FragLength`, so the padding never reaches reassembly or the handshake transcript. An unpadded frame (present bytes == `FragLength`) parses exactly as before, so this is backward compatible; a frame with fewer bytes than `FragLength` is still rejected.
- `pkg/tunnel/dgram_handshake.go` - `fragmentHandshake` takes a `pad bool` and, when set, zero-extends each encoded frame to `DatagramMTU`. `FragLength` and `TotalLength` are unchanged, so reassembly is unaffected.
- `pkg/tunnel/dgram_rekey.go` - `fragmentRekey` takes the same `pad` flag (rekey is the same PQ exchange mid-session, so it has the same fingerprint).
- `pkg/tunnel/datagram.go` - new `padHandshake` field and the `WithHandshakePadding()` option; `NewDatagramEndpoint` now takes options. The handshake send loop and both rekey send paths thread the endpoint's flag through.

The reassembler is intentionally unchanged: because the parser slices the fragment to `FragLength` before `Reassembler.Add` ever sees it, `Add` always receives exactly `FragLength` bytes, so its existing length check still holds.

## Security

- The padding sits outside `FragLength`, so it never enters the reassembled message or the handshake transcript. An attacker mangling the padding changes nothing (it is sliced off), and padding cannot smuggle bytes into the authenticated handshake.
- It does not change per-source reassembly memory, which is sized by the declared `TotalLength`, not the datagram size.
- It cannot weaken the anti-amplification bound: a RETRY is only ever emitted when it is no larger than the triggering datagram, regardless of how that datagram is padded.
- The receiver tolerates padding unconditionally, so a padding peer interoperates with a non-padding one; for full effect both ends enable it. The transport is pre-release, so there is no deployed-old-receiver compatibility concern.

## Tests

- `pkg/protocol/datagram_padding_test.go` - the parser accepts a frame with trailing padding and returns the exact unpadded fragment, still round-trips unpadded frames, and still rejects a fragment shorter than `FragLength`.
- `pkg/tunnel/dgram_padding_test.go` - with padding on every frame is exactly the MTU and a padded flight still reassembles to the identical message; with padding off frames are not all MTU-sized; and a full padded handshake completes end to end over the in-memory pipe with data flowing both ways while every handshake datagram either side emitted is exactly the MTU.
- `test/fuzz/datagram_fuzz_test.go` - the handshake-parse fuzz seed now includes a trailing-padded frame.