### PR TITLE
cut datagram receive allocations with a coarse activity clock and borrowed recv buffer

### DIFF
--- a/pkg/tunnel/coarsetime.go
+++ b/pkg/tunnel/coarsetime.go
@@ -1,0 +1,45 @@
+package tunnel
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Coarse monotonic-ish wall clock for the datagram hot path.
+//
+// The data path stamps a per-session "last activity" time on every sealed and
+// opened datagram, read only by the idle reaper (a 120s window checked every
+// ~30s). Calling time.Now() twice per datagram showed up as ~7% of the
+// end-to-end CPU profile purely to feed that coarse-grained reaper. Instead, one
+// process-lifetime goroutine refreshes a shared timestamp ~10x/sec and the hot
+// path reads it with a single atomic load. 100ms granularity is irrelevant
+// against a 120s idle timeout, and the value is never used for any cryptographic
+// freshness decision (cookies, replay, and rekey all carry their own timing).
+const coarseTickInterval = 100 * time.Millisecond
+
+var (
+	coarseNanos atomic.Int64
+	coarseOnce  sync.Once
+)
+
+// coarseTimeNanos returns the current time in Unix nanoseconds at ~100ms
+// resolution. The first call lazily starts a single background updater goroutine
+// (so processes that never use the datagram transport pay nothing); the goroutine
+// then runs for the lifetime of the process - a fixed one-goroutine cost, not a
+// per-endpoint leak.
+func coarseTimeNanos() int64 {
+	coarseOnce.Do(startCoarseClock)
+	return coarseNanos.Load()
+}
+
+func startCoarseClock() {
+	coarseNanos.Store(time.Now().UnixNano())
+	go func() {
+		ticker := time.NewTicker(coarseTickInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			coarseNanos.Store(time.Now().UnixNano())
+		}
+	}()
+}

--- a/pkg/tunnel/coarsetime_test.go
+++ b/pkg/tunnel/coarsetime_test.go
@@ -1,0 +1,30 @@
+package tunnel
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCoarseTimeNanos checks the coarse clock returns a plausible current time and
+// advances over time. It does not assert exact granularity (that is an internal
+// tuning detail); it only pins the two properties the idle reaper depends on: the
+// value is a real Unix-nanos timestamp, and it moves forward.
+func TestCoarseTimeNanos(t *testing.T) {
+	got := coarseTimeNanos()
+	now := time.Now().UnixNano()
+	// Within a generous window of wall clock (the updater seeds from time.Now on
+	// first use, then refreshes on a ticker).
+	if delta := now - got; delta < -int64(time.Second) || delta > int64(2*time.Second) {
+		t.Fatalf("coarseTimeNanos = %d, wall clock = %d, delta %v out of range", got, now, time.Duration(delta))
+	}
+
+	// It must advance within a few tick intervals.
+	start := coarseTimeNanos()
+	deadline := time.Now().Add(2 * time.Second)
+	for coarseTimeNanos() == start {
+		if time.Now().After(deadline) {
+			t.Fatal("coarse clock did not advance within 2s")
+		}
+		time.Sleep(coarseTickInterval)
+	}
+}

--- a/pkg/tunnel/dgram_batch.go
+++ b/pkg/tunnel/dgram_batch.go
@@ -14,9 +14,18 @@ import (
 // dgram_batch_linux.go / dgram_batch_other.go.
 type batchIO interface {
 	// recv reads one batch of datagrams and calls dispatch for each, in arrival
-	// order, with a freshly-allocated payload copy the callee may retain. It blocks
-	// until at least one datagram is available and returns the underlying read
-	// error (e.g. on close) so the receive loop can exit.
+	// order. It blocks until at least one datagram is available and returns the
+	// underlying read error (e.g. on close) so the receive loop can exit.
+	//
+	// CONTRACT: the payload is borrowed - it is backed by a reusable receive buffer
+	// and is valid ONLY for the duration of the dispatch call. The callee MUST copy
+	// any bytes it needs to retain past return. routeDatagram (the sole dispatcher)
+	// already honors this: the handshake reassembler copies each fragment, the RETRY
+	// path copies the cookie, CLOSE is consumed synchronously, and a DATA frame's
+	// delivered plaintext is freshly allocated by the AEAD Open (it does not alias
+	// the payload). Eliminating the per-datagram copy here removes an allocation on
+	// the receive hot path; if a future change makes routeDatagram retain the
+	// payload, it must copy explicitly or this breaks.
 	recv(dispatch func(src net.Addr, payload []byte)) error
 	// writeAll writes every frame to dst, best-effort: write errors are ignored,
 	// matching the single-shot send sites (handshake/rekey retransmission recovers
@@ -43,9 +52,8 @@ func (f *fallbackIO) recv(dispatch func(src net.Addr, payload []byte)) error {
 	if err != nil {
 		return err
 	}
-	data := make([]byte, n)
-	copy(data, f.buf[:n])
-	dispatch(src, data)
+	// Borrowed buffer: dispatch must not retain it (see recv contract). No copy.
+	dispatch(src, f.buf[:n])
 	return nil
 }
 

--- a/pkg/tunnel/dgram_batch_linux.go
+++ b/pkg/tunnel/dgram_batch_linux.go
@@ -46,11 +46,11 @@ func (b *linuxBatchIO) recv(dispatch func(src net.Addr, payload []byte)) error {
 	}
 	for i := 0; i < n; i++ {
 		m := &b.rmsgs[i]
-		// Copy out before the next ReadBatch overwrites the shared buffer; the
-		// payload is routed onward (reassembly / recvCh) and outlives this call.
-		data := make([]byte, m.N)
-		copy(data, m.Buffers[0][:m.N])
-		dispatch(m.Addr, data)
+		// Borrowed buffer: dispatch must not retain it (see the recv contract in
+		// dgram_batch.go). Each message has its own backing buffer in rmsgs, and the
+		// next ReadBatch only overwrites them after this loop returns, so passing the
+		// slice directly is safe and avoids a per-datagram copy.
+		dispatch(m.Addr, m.Buffers[0][:m.N])
 	}
 	return nil
 }

--- a/pkg/tunnel/dgram_batch_test.go
+++ b/pkg/tunnel/dgram_batch_test.go
@@ -65,7 +65,9 @@ func TestFallbackIORecvDispatchesEachDatagram(t *testing.T) {
 			if src != addr {
 				t.Errorf("src = %v, want %v", src, addr)
 			}
-			got = append(got, payload)
+			// The payload is borrowed (valid only during dispatch), so copy it to
+			// compare after the loop - exactly what a retaining caller must do.
+			got = append(got, append([]byte(nil), payload...))
 		})
 		if err != nil {
 			break
@@ -82,9 +84,12 @@ func TestFallbackIORecvDispatchesEachDatagram(t *testing.T) {
 	}
 }
 
-func TestFallbackIORecvCopiesPayload(t *testing.T) {
-	// recv must hand the callee a copy that survives the reuse of the read buffer
-	// on the following recv.
+func TestFallbackIORecvPayloadBorrowed(t *testing.T) {
+	// The recv payload is borrowed: correct during dispatch, and a copy taken
+	// during dispatch survives a later recv that reuses the buffer. (The old
+	// contract handed out a fresh copy per call; recv now passes the reused buffer
+	// directly to avoid a per-datagram allocation, so retaining without copying is a
+	// caller bug - this test pins the copy-during-dispatch behavior callers rely on.)
 	addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}
 	conn := &scriptedConn{reads: []scriptedPkt{
 		{data: []byte("first"), addr: addr},
@@ -92,12 +97,18 @@ func TestFallbackIORecvCopiesPayload(t *testing.T) {
 	}}
 
 	bio := newBatchIO(conn)
-	var retained []byte
-	_ = bio.recv(func(_ net.Addr, payload []byte) { retained = payload })
-	_ = bio.recv(func(_ net.Addr, _ []byte) {})
 
-	if !bytes.Equal(retained, []byte("first")) {
-		t.Fatalf("retained payload corrupted by a later recv: %q", retained)
+	var duringDispatch, copied []byte
+	_ = bio.recv(func(_ net.Addr, payload []byte) {
+		duringDispatch = payload                 // borrowed view
+		copied = append([]byte(nil), payload...) // what a retaining caller does
+	})
+	if !bytes.Equal(duringDispatch, []byte("first")) {
+		t.Fatalf("payload during dispatch = %q, want %q", duringDispatch, "first")
+	}
+	_ = bio.recv(func(_ net.Addr, _ []byte) {})
+	if !bytes.Equal(copied, []byte("first")) {
+		t.Fatalf("a copy taken during dispatch must survive a later recv: got %q", copied)
 	}
 }
 

--- a/pkg/tunnel/dgram_session.go
+++ b/pkg/tunnel/dgram_session.go
@@ -158,7 +158,7 @@ func (s *Session) DatagramSeal(aad []byte, seq uint64, plaintext []byte) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	s.lastActivityNanos.Store(time.Now().UnixNano())
+	s.lastActivityNanos.Store(coarseTimeNanos())
 	return ct, nil
 }
 
@@ -182,7 +182,7 @@ func (s *Session) DatagramOpen(epoch uint8, seq uint64, ciphertext, aad []byte) 
 	if err != nil {
 		return nil, err
 	}
-	s.lastActivityNanos.Store(time.Now().UnixNano())
+	s.lastActivityNanos.Store(coarseTimeNanos())
 	return pt, nil
 }
 

--- a/pkg/tunnel/dgram_session_inplace.go
+++ b/pkg/tunnel/dgram_session_inplace.go
@@ -7,8 +7,6 @@
 package tunnel
 
 import (
-	"time"
-
 	"github.com/sara-star-quant/quantum-go/internal/constants"
 	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
 )
@@ -35,7 +33,7 @@ func (s *Session) DatagramSealTo(dst, aad []byte, seq uint64, plaintext []byte) 
 	if err != nil {
 		return nil, err
 	}
-	s.lastActivityNanos.Store(time.Now().UnixNano())
+	s.lastActivityNanos.Store(coarseTimeNanos())
 	return out, nil
 }
 
@@ -57,6 +55,6 @@ func (s *Session) DatagramOpenTo(dst []byte, epoch uint8, seq uint64, ciphertext
 	if err != nil {
 		return nil, err
 	}
-	s.lastActivityNanos.Store(time.Now().UnixNano())
+	s.lastActivityNanos.Store(coarseTimeNanos())
 	return pt, nil
 }


### PR DESCRIPTION
## What

Cuts two per-datagram costs the end-to-end CPU profile flagged: the `time.Now()` activity stamp (~7%) and the receive-path copy/allocation (~11%). No wire-format, crypto, or API change.

## Why

A CPU profile of `BenchmarkDatagramEndToEnd` showed ~7% in `time.Now` (called twice per datagram, on every seal and every open, only to feed the idle reaper) and ~11% in `runtime.mallocgc`, dominated by the per-datagram `make([]byte, n)` copy on the receive path. Neither cost buys anything: the activity stamp feeds a 120s idle timeout checked every ~30s, and nothing downstream retains the raw receive buffer.

## How

- `pkg/tunnel/coarsetime.go` (new) - one process-lifetime goroutine refreshes a shared timestamp every 100ms; the hot path reads it with a single atomic load. 100ms granularity is irrelevant against a 120s idle timeout, and the stamp never feeds a cryptographic freshness check (cookies, replay, and rekey all carry their own timing). The updater starts lazily on first use, so a process that never uses the datagram transport pays nothing. The four hot-path stamp sites (`DatagramSealTo`/`DatagramOpenTo`, `DatagramSeal`/`DatagramOpen`) switch to it; one-time establishment stamps keep `time.Now`.
- `pkg/tunnel/dgram_batch.go`, `dgram_batch_linux.go` - `recv` now lends the reused receive buffer to `dispatch` under an explicit borrow contract (payload valid only during the call) instead of allocating a copy per datagram. This is safe because `routeDatagram` never retains the raw frame: the reassembler copies each handshake fragment, the RETRY path copies the cookie, CLOSE is consumed synchronously, and the AEAD Open returns a fresh plaintext slice for DATA frames (it does not alias the input). The contract is documented loudly so a future retaining change copies explicitly.

## Measured (Linux container, arm64 - indicative, a VM depresses absolutes; relative deltas are sound; two passes)

| Benchmark | Before | After |
|---|---|---|
| Receive (`recvmmsg` batch) | 3 allocs, ~1340 B/op, ~945 MB/s | 2 allocs, ~62 B/op, ~1080-1140 MB/s |
| Receive (one syscall per datagram) | 4 allocs, ~1348 B/op, ~830 MB/s | 3 allocs, ~68 B/op, ~905-1085 MB/s |
| End-to-end (one-way single flow, delivered) | 6 allocs, ~230 MB/s | 5 allocs, ~257-285 MB/s |
| Send (isolated, control) | 1 alloc, ~1250 MB/s | 1 alloc, ~1254 MB/s (unchanged, expected) |

## Tests

`TestCoarseTimeNanos` (plausible time + advances); `TestFallbackIORecvPayloadBorrowed` and the dispatch test updated for the borrow contract (copy-during-dispatch survives a later recv). Full suite green under `-race`; `golangci-lint` (Linux container) and `gofmt` clean; builds on linux/darwin/windows.
