### PR TITLE
add aggregate multi-flow and backlog datagram throughput benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GOMOD=$(GOCMD) mod
 GOFMT=$(GOCMD) fmt
 
 # Targets
-.PHONY: all build clean test coverage bench install uninstall help \
+.PHONY: all build clean test coverage bench bench-datagram install uninstall help \
         build-linux build-darwin build-windows build-all \
         docker release
 
@@ -120,6 +120,11 @@ coverage:
 bench:
 	@echo "Running benchmarks..."
 	$(GOTEST) -bench=. -benchmem ./test/benchmark/
+
+## bench-datagram: Run datagram data-plane throughput benchmarks (run on Linux for representative numbers)
+bench-datagram:
+	@echo "Running datagram benchmarks (single-flow, aggregate multi-flow, and receive batch vs single)..."
+	$(GOTEST) -run '^$$' -bench 'BenchmarkDatagram' -benchmem ./pkg/tunnel/
 
 ## fuzz: Run fuzz tests
 fuzz:

--- a/pkg/tunnel/dgram_perf_test.go
+++ b/pkg/tunnel/dgram_perf_test.go
@@ -1,7 +1,9 @@
 package tunnel
 
 import (
+	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -134,6 +136,264 @@ func BenchmarkDatagramEndToEnd(b *testing.B) {
 	if got := atomic.LoadInt64(&received); got < int64(b.N)-window {
 		b.Fatalf("delivered %d of %d datagrams: drops are inflating the throughput number", got, b.N)
 	}
+}
+
+// dialFlows establishes n concurrent sessions into one shared responder endpoint,
+// each from its own initiator endpoint (socket). One initiator per flow is both
+// realistic (n clients = n sockets) and necessary: the responder bootstraps a new
+// handshake keyed by source address for the RecvIndex-0 ClientHello, so several
+// simultaneous handshakes from one source would collide at bootstrap (they are only
+// index-demuxed after establishment). The shared responder endpoint is the system
+// under test - its single Serve goroutine demuxes and drains all n flows. Returns
+// the n initiator conns paired with their responder sessions and a stop func.
+func dialFlows(tb testing.TB, n int) (clients []*DatagramConn, servers []*datagramSession, stop func()) {
+	tb.Helper()
+	rxB, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		tb.Fatalf("listen responder: %v", err)
+	}
+	// A real server sets a large receive buffer; without it the default socket
+	// buffer drops heavily under many concurrent flows (worse on macOS loopback),
+	// which would make the aggregate number reflect the test harness, not the
+	// transport. Best-effort: the OS may clamp it.
+	_ = rxB.SetReadBuffer(8 << 20)
+	epB, err := NewDatagramEndpoint(rxB)
+	if err != nil {
+		tb.Fatalf("responder endpoint: %v", err)
+	}
+	go epB.Serve()
+
+	initiators := make([]*DatagramEndpoint, 0, n)
+	type dialResult struct {
+		conn *DatagramConn
+		err  error
+	}
+	dialCh := make(chan dialResult, n)
+	for range n {
+		rxA, lerr := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		if lerr != nil {
+			tb.Fatalf("listen initiator: %v", lerr)
+		}
+		epA, eerr := NewDatagramEndpoint(rxA)
+		if eerr != nil {
+			tb.Fatalf("initiator endpoint: %v", eerr)
+		}
+		go epA.Serve()
+		initiators = append(initiators, epA)
+		go func() {
+			c, derr := DialDatagram(epA, rxB.LocalAddr())
+			dialCh <- dialResult{c, derr}
+		}()
+	}
+	for range n {
+		select {
+		case ds := <-epB.acceptCh:
+			servers = append(servers, ds)
+		case <-time.After(10 * time.Second):
+			tb.Fatalf("only %d of %d responder sessions surfaced", len(servers), n)
+		}
+		select {
+		case r := <-dialCh:
+			if r.err != nil {
+				tb.Fatalf("dial: %v", r.err)
+			}
+			clients = append(clients, r.conn)
+		case <-time.After(10 * time.Second):
+			tb.Fatalf("only %d of %d dials completed", len(clients), n)
+		}
+	}
+
+	stop = func() {
+		_ = epB.Close()
+		for _, ep := range initiators {
+			_ = ep.Close()
+		}
+	}
+	return clients, servers, stop
+}
+
+// BenchmarkDatagramEndToEndFlows measures AGGREGATE delivered goodput across N
+// concurrent flows into one shared responder endpoint - the server-relevant number,
+// where one Serve goroutine demuxes and drains all flows. Run with -benchmem and
+// e.g. -cpu=1,4,8 to see how aggregate throughput scales with cores.
+//
+// Each flow is closed-loop rate-matched: a per-flow credit window bounds in-flight
+// datagrams, and the drainer returns a credit on each delivery, so the sender
+// naturally paces to the rate the receiver can sustain (no blasting, so almost
+// nothing is dropped and the number is honest goodput). Two safety mechanisms keep
+// it from the failure modes earlier versions hit: a large responder receive buffer
+// (set in dialFlows) makes kernel drops rare, and a watchdog tops up each flow's
+// credits every 100ms so a datagram the kernel does drop cannot permanently remove
+// a credit and wedge the sender (the deadlock a strict credit window hit). The
+// watchdog's top-up rate is negligible against the real delivery rate, so it does
+// not distort the measurement the way a per-send timeout did. SetBytes reports the
+// send rate; recv-MB/s reports delivered goodput over the same wall-clock - the two
+// track closely while the responder keeps up and diverge once it saturates.
+func BenchmarkDatagramEndToEndFlows(b *testing.B) {
+	// 1..8 flows shows the scaling curve; the single responder Serve goroutine
+	// saturates within this range, so higher counts add only contention (and, in a
+	// resource-constrained CI container, socket/goroutine pressure across the shared
+	// benchmark process) without new signal.
+	for _, flows := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("flows=%d", flows), func(b *testing.B) {
+			clients, servers, stop := dialFlows(b, flows)
+			defer stop()
+
+			payload := make([]byte, constants.DatagramMaxDataPayload)
+			const window = 16 // per-flow in-flight bound; well below dataInboxCap (64)
+			var received int64
+			stopDrain := make(chan struct{})
+			var drainWG sync.WaitGroup
+
+			// Per-flow credit semaphores (buffered channels), pre-filled to the window.
+			credits := make([]chan struct{}, flows)
+			for i := range credits {
+				credits[i] = make(chan struct{}, window)
+				for range window {
+					credits[i] <- struct{}{}
+				}
+			}
+
+			// One drainer per responder session: count the delivery and return a credit
+			// to its flow (non-blocking - the window cap means the channel can be full).
+			for i := range servers {
+				srv, cr := servers[i], credits[i]
+				drainWG.Add(1)
+				go func() {
+					defer drainWG.Done()
+					for {
+						select {
+						case <-srv.recvCh:
+							atomic.AddInt64(&received, 1)
+							select {
+							case cr <- struct{}{}:
+							default:
+							}
+						case <-srv.closed:
+							return
+						case <-stopDrain:
+							return
+						}
+					}
+				}()
+			}
+
+			// Watchdog: restore a credit per flow every 100ms so a kernel-dropped
+			// datagram (whose credit the drainer never returns) cannot permanently wedge
+			// a sender. Far below the real delivery rate, so it does not pace the bench.
+			go func() {
+				t := time.NewTicker(100 * time.Millisecond)
+				defer t.Stop()
+				for {
+					select {
+					case <-t.C:
+						for _, cr := range credits {
+							select {
+							case cr <- struct{}{}:
+							default:
+							}
+						}
+					case <-stopDrain:
+						return
+					}
+				}
+			}()
+
+			b.SetBytes(int64(len(payload)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			// Spread b.N sends across the flows concurrently so all cores stay busy.
+			// Capture the first send error atomically rather than calling b.Errorf from
+			// these goroutines: testing.B is not safe for concurrent Errorf, and CI runs
+			// under -race. Report it on the main goroutine after the senders join.
+			var wg sync.WaitGroup
+			var sendErr atomic.Value
+			per := b.N / flows
+			for i := range clients {
+				count := per
+				if i == len(clients)-1 {
+					count = b.N - per*(flows-1) // remainder on the last flow
+				}
+				c, cr := clients[i], credits[i]
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for range count {
+						<-cr
+						if err := c.Send(payload); err != nil {
+							sendErr.CompareAndSwap(nil, err)
+							return
+						}
+					}
+				}()
+			}
+			wg.Wait()
+			elapsed := b.Elapsed()
+			b.StopTimer()
+			close(stopDrain)
+			drainWG.Wait() // do not leak drainers into the next sub-benchmark
+
+			if err, _ := sendErr.Load().(error); err != nil {
+				b.Fatalf("send: %v", err)
+			}
+			if secs := elapsed.Seconds(); secs > 0 {
+				got := atomic.LoadInt64(&received)
+				b.ReportMetric(float64(got*int64(len(payload)))/secs/1e6, "recv-MB/s")
+			}
+		})
+	}
+}
+
+// BenchmarkDatagramRecvBacklog measures the receive path under a real backlog: a
+// background flood keeps the socket buffer full so each recvmmsg ReadBatch returns
+// a full batch, which is the condition recvmmsg amortization is for (the matched-
+// rate BenchmarkDatagramRecv* return only 1-2 datagrams per call and hide it). It
+// drives the batchIO recv directly (raw datagrams, no session), so it isolates the
+// syscall-batching effect from the crypto path. Compare batch vs single here for the
+// honest recvmmsg win.
+func BenchmarkDatagramRecvBacklog(b *testing.B) {
+	rx, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		b.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = rx.Close() }()
+	// A large socket receive buffer lets the flood build a real backlog.
+	_ = rx.SetReadBuffer(4 << 20)
+	tx, err := net.DialUDP("udp", nil, rx.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		b.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = tx.Close() }()
+
+	payload := make([]byte, constants.DatagramMaxDataPayload)
+	stop := make(chan struct{})
+	// Several flooders to keep the buffer full even as the receiver drains fast.
+	for range 3 {
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = tx.Write(payload)
+				}
+			}
+		}()
+	}
+
+	bio := newBatchIO(rx)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	received := 0
+	for received < b.N {
+		if err := bio.recv(func(_ net.Addr, _ []byte) { received++ }); err != nil {
+			b.Fatalf("recv: %v", err)
+		}
+	}
+	b.StopTimer()
+	close(stop)
 }
 
 // handshakeWireBytes sums the on-wire bytes of one handshake flight (here a


### PR DESCRIPTION
## What

Adds the two datagram throughput benchmarks the single-flow benchmark cannot provide: aggregate goodput across N concurrent flows, and receive throughput under a real backlog (where recvmmsg actually amortizes). Plus a `make bench-datagram` target. Benchmarks only, no production code.

## Why

Phase 0 measures one flow. A server runs many, and the matched-rate receive benchmarks return only 1-2 datagrams per `recvmmsg` so they hide the batch win. These two benchmarks fill those gaps and surface where the transport's per-endpoint ceiling is.

## How

- `BenchmarkDatagramEndToEndFlows` - N concurrent flows into one shared responder endpoint, each flow from its own initiator socket (the responder bootstraps a handshake by source address, so multiple handshakes from one socket would collide at bootstrap). Each flow runs closed-loop with a per-flow credit window returned by the drainer on delivery, so the reported `recv-MB/s` is honest delivered goodput, tracking `send-MB/s` (SetBytes). A large responder receive buffer plus a 100ms credit-top-up watchdog keep it deadlock-proof: a kernel-dropped datagram cannot permanently remove a credit and wedge a sender, and the top-up rate stays far below the real delivery rate so it does not pace the measurement.
- `BenchmarkDatagramRecvBacklog` - drives `batchIO.recv` directly under a sustained 3-flooder flood with a 4 MB socket buffer, so each `ReadBatch` fills - the apples-to-apples batch-vs-single comparison the matched-rate benchmarks cannot make.
- `Makefile` - `bench-datagram` target.

## Measured (Linux container, arm64 - indicative; a VM depresses absolutes, relative shape is the point; two passes)

Aggregate delivered goodput by flow count (send-MB/s ≈ recv-MB/s throughout, confirming the goodput discipline):

| flows | pass 1 | pass 2 |
|---|---|---|
| 1 | 257 | 266 |
| 2 | 300 | 314 |
| 4 | 315 | 371 |
| 8 | 248 | 321 |

The curve rises to ~4 flows then plateaus/dips - the single responder `Serve` goroutine saturates there. That is the concrete motivation for the receive-parallelism / GSO-GRO work tracked on the roadmap (Phase 3). recvmmsg backlog ~915 MB/s; isolated send ~1.2 GB/s.

## Notes

The aggregate benchmark went through several wrong designs before this one (a strict credit window deadlocked on a kernel drop; an unbounded blast measured ~99% drops; a per-send timeout distorted the saturated case). The credit-window + watchdog design above is the one that is both deadlock-proof and undistorted; the flow sweep is capped at 8 because the responder saturates well before then and higher counts only add socket/goroutine pressure in a shared CI process. Verified green under `-race` (combined and isolated), `golangci-lint` (Linux container) and `gofmt` clean, builds on linux/darwin/windows.
