### PR TITLE
scale datagram receive across cores with SO_REUSEPORT

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -178,6 +178,12 @@ const (
 	// per-endpoint receive buffer set (DatagramBatchSize * (DatagramMTU+512)).
 	DatagramBatchSize = 32
 
+	// DatagramMaxReceiveSockets caps how many SO_REUSEPORT receive sockets
+	// ListenDatagram opens (default min(GOMAXPROCS, this)). It bounds the parallel
+	// receive fan-out: enough to spread demux + AEAD-open across cores on a typical
+	// server without opening an unbounded number of sockets and goroutines.
+	DatagramMaxReceiveSockets = 8
+
 	// DatagramNoncePrefixSize is the size of the per-session random nonce prefix.
 	// The 12-byte AEAD nonce is the prefix followed by the 8-byte sequence
 	// number, so the prefix is the AEAD nonce size minus 8.

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -17,6 +17,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -276,19 +277,42 @@ func (r *connRegistry) knownSource(index uint32, src string) bool {
 	return ok
 }
 
-// addSource registers an in-progress responder handshake under its source so a
-// retransmitted ClientHello (which still carries RecvIndex 0) routes to it.
+// reserveSource makes the bootstrap decision for a RecvIndex-0 ClientHello from
+// source atomically under one lock, so concurrent receive goroutines (the
+// SO_REUSEPORT parallel-receive path) cannot both start a responder for the same new
+// source. The caller passes a freshly-built (not-yet-keyed) session to install if
+// source is new. It returns:
+//   - (ds, true): source was new and admitted - the passed session is now registered
+//     in bySource and a half-open slot is claimed; the caller MUST run startResponder
+//     with this session and release the slot on failure. Registering in bySource
+//     here (not later, after the slow CH-KEM work in startResponder) is what closes
+//     the window where a second goroutine could also start a responder.
+//   - (existing, false): a responder for source already exists (this goroutine raced
+//     a retransmit, or the kernel hashed two copies to two sockets); the caller
+//     routes the ClientHello to existing and discards its freshly-built session.
+//   - (nil, false): the per-source half-open cap is reached; the caller drops.
+func (r *connRegistry) reserveSource(source string, fresh *datagramSession) (ds *datagramSession, reserved bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing := r.bySource[source]; existing != nil {
+		return existing, false
+	}
+	if r.halfOpen[source] >= constants.DatagramMaxHalfOpenPerSource {
+		return nil, false
+	}
+	r.bySource[source] = fresh
+	r.halfOpen[source]++
+	r.halfOpenTotal++
+	return fresh, true
+}
+
+// addSource registers an in-progress responder handshake under its source. The
+// production bootstrap path installs the session atomically via reserveSource; this
+// remains as a direct primitive for tests that set up registry state.
 func (r *connRegistry) addSource(source string, s *datagramSession) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.bySource[source] = s
-}
-
-// lookupSource returns the in-progress responder handshake for a source, or nil.
-func (r *connRegistry) lookupSource(source string) *datagramSession {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.bySource[source]
 }
 
 // removeSource drops the source mapping (on establishment or teardown). It is
@@ -303,11 +327,19 @@ func (r *connRegistry) removeSource(source string) {
 // It demultiplexes incoming datagrams to per-session state by connection index
 // and surfaces newly-established inbound sessions on an accept channel.
 type DatagramEndpoint struct {
-	conn     net.PacketConn
-	batch    batchIO
-	registry *connRegistry
-	reasm    *Reassembler
-	acceptCh chan *datagramSession
+	// conn is the designated send socket and the primary receive socket; batch is
+	// its batchIO. All outbound sends (data plane, cookie RETRY, handshake/rekey
+	// flights) go through conn. With SO_REUSEPORT parallel receive (ListenDatagram),
+	// extraBatch holds the batchIO for the additional receive sockets; Serve runs one
+	// receive goroutine per socket, all dispatching into the shared, concurrency-safe
+	// routeDatagram. extraConns keeps those sockets only so Close can shut them.
+	conn       net.PacketConn
+	batch      batchIO
+	extraConns []net.PacketConn
+	extraBatch []batchIO
+	registry   *connRegistry
+	reasm      *Reassembler
+	acceptCh   chan *datagramSession
 
 	// cookie mints and verifies stateless return-routability cookies for the
 	// anti-DoS gate (see dgram_cookie.go).
@@ -333,6 +365,11 @@ type DatagramEndpoint struct {
 	// with a non-padding one; full hiding needs both ends to enable it.
 	padHandshake bool
 
+	// receiveSockets is the requested SO_REUSEPORT socket count for ListenDatagram,
+	// set by WithReceiveSockets; 0 means use the default. Ignored by
+	// NewDatagramEndpoint.
+	receiveSockets int
+
 	closeOnce sync.Once
 	done      chan struct{}
 }
@@ -349,11 +386,30 @@ func WithHandshakePadding() DatagramEndpointOption {
 	return func(e *DatagramEndpoint) { e.padHandshake = true }
 }
 
+// WithReceiveSockets sets how many SO_REUSEPORT receive sockets ListenDatagram
+// opens (clamped to [1, DatagramMaxReceiveSockets]). More sockets let the kernel
+// spread inbound datagrams across more cores, raising aggregate receive throughput
+// for a busy multi-session server. The default is min(GOMAXPROCS,
+// DatagramMaxReceiveSockets). It has no effect on NewDatagramEndpoint (single
+// socket) or on platforms without SO_REUSEPORT (which degrade to one socket).
+func WithReceiveSockets(n int) DatagramEndpointOption {
+	return func(e *DatagramEndpoint) { e.receiveSockets = n }
+}
+
 // NewDatagramEndpoint wraps a PacketConn (a *net.UDPConn in production, or a
 // fault-injecting conn in tests). It does not start the receive loop; callers
 // start it explicitly so tests can drive routing deterministically. It returns an
 // error only if the per-endpoint cookie secret cannot be drawn from the CSPRNG.
+//
+// It serves a single socket. For a server that wants the receive path spread across
+// cores, use ListenDatagram.
 func NewDatagramEndpoint(conn net.PacketConn, opts ...DatagramEndpointOption) (*DatagramEndpoint, error) {
+	return newEndpoint(conn, opts)
+}
+
+// newEndpoint builds an endpoint around its primary (send + first receive) conn and
+// applies opts. ListenDatagram fills extraConns/extraBatch afterward.
+func newEndpoint(conn net.PacketConn, opts []DatagramEndpointOption) (*DatagramEndpoint, error) {
 	cookie, err := newCookieSigner(nil)
 	if err != nil {
 		return nil, err
@@ -377,6 +433,49 @@ func NewDatagramEndpoint(conn net.PacketConn, opts ...DatagramEndpointOption) (*
 	return e, nil
 }
 
+// ListenDatagram opens a datagram endpoint on (network, addr) whose receive path is
+// spread across multiple SO_REUSEPORT sockets so demux and AEAD-open scale across
+// cores - the way a busy multi-session tunnel server reaches aggregate throughput
+// past a single core. network is "udp", "udp4", or "udp6". The socket count is
+// WithReceiveSockets, defaulting to min(GOMAXPROCS, DatagramMaxReceiveSockets);
+// addr may use port 0 to get an ephemeral port (resolved once and shared by all
+// sockets). On platforms without SO_REUSEPORT it transparently uses one socket.
+//
+// Callers start the receive loop with Serve, as with NewDatagramEndpoint.
+func ListenDatagram(network, addr string, opts ...DatagramEndpointOption) (*DatagramEndpoint, error) {
+	probe := &DatagramEndpoint{}
+	for _, opt := range opts {
+		opt(probe)
+	}
+	n := probe.receiveSockets
+	if n <= 0 {
+		n = runtime.GOMAXPROCS(0)
+	}
+	if n > constants.DatagramMaxReceiveSockets {
+		n = constants.DatagramMaxReceiveSockets
+	}
+	if n < 1 {
+		n = 1
+	}
+
+	conns, err := listenReusePort(network, addr, n)
+	if err != nil {
+		return nil, err
+	}
+	e, err := newEndpoint(conns[0], opts)
+	if err != nil {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		return nil, err
+	}
+	for _, c := range conns[1:] {
+		e.extraConns = append(e.extraConns, c)
+		e.extraBatch = append(e.extraBatch, newBatchIO(c))
+	}
+	return e, nil
+}
+
 // underCookiePressure reports whether the endpoint should demand a
 // return-routability cookie from new sources. Either the in-progress reassembly
 // source count or the global half-open count crossing the high-water mark trips
@@ -388,30 +487,59 @@ func (e *DatagramEndpoint) underCookiePressure() bool {
 		e.registry.halfOpenLoad() >= e.cookiePressureHighWater
 }
 
-// Close shuts the endpoint down and closes the underlying PacketConn. It is
-// idempotent and safe for concurrent use.
+// Close shuts the endpoint down and closes every underlying socket (the send conn
+// and any extra SO_REUSEPORT receive sockets). It is idempotent and safe for
+// concurrent use. Closing the sockets unblocks all receive goroutines in Serve.
 func (e *DatagramEndpoint) Close() error {
 	var err error
 	e.closeOnce.Do(func() {
 		close(e.done)
 		err = e.conn.Close()
+		for _, c := range e.extraConns {
+			if cerr := c.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
+		}
 	})
 	return err
 }
 
-// Serve runs the receive loop: it reads datagrams and dispatches each through
-// routeDatagram until the endpoint is closed. Callers run it in their own
-// goroutine (go ep.Serve()). It returns when the underlying conn is closed.
+// Serve runs the receive loop until the endpoint is closed. It dispatches every
+// datagram through routeDatagram. Callers run it in their own goroutine
+// (go ep.Serve()); it returns when the sockets are closed.
+//
+// With SO_REUSEPORT parallel receive (ListenDatagram), it runs one receive
+// goroutine per socket - the kernel load-balances inbound datagrams across the
+// sockets by flow hash, so demux and AEAD-open scale across cores. routeDatagram is
+// concurrency-safe (the registry, each session's replay window, and the reassembler
+// are all mutex-guarded, and the RecvIndex-0 bootstrap goes through the atomic
+// reserveSource), so the goroutines need no further coordination. A single-socket
+// endpoint (NewDatagramEndpoint) runs exactly one receive goroutine, as before.
 func (e *DatagramEndpoint) Serve() {
 	go e.reapIdle()
 	dispatch := func(src net.Addr, data []byte) {
 		_ = e.routeDatagram(src, data)
 	}
-	for {
-		if err := e.batch.recv(dispatch); err != nil {
-			return
+	recvLoop := func(bio batchIO) {
+		for {
+			if err := bio.recv(dispatch); err != nil {
+				return
+			}
 		}
 	}
+	if len(e.extraBatch) == 0 {
+		recvLoop(e.batch) // single-socket: stay on the caller's goroutine, as before
+		return
+	}
+	var wg sync.WaitGroup
+	for _, bio := range append([]batchIO{e.batch}, e.extraBatch...) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			recvLoop(bio)
+		}()
+	}
+	wg.Wait()
 }
 
 // reapIdle tears down sessions with no datagram activity within idleTimeout. It

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -60,37 +60,45 @@ func (e *DatagramEndpoint) deliverHandshake(src net.Addr, h protocol.DatagramHan
 	if h.MsgType != protocol.MessageTypeClientHello {
 		return
 	}
-	if ds := e.registry.lookupSource(src.String()); ds != nil {
-		trySend(ds.inbox, in)
-		return
-	}
-	if !e.registry.tryAddHalfOpen(src.String()) {
-		return
-	}
-	e.startResponder(src, in)
-}
-
-// startResponder allocates the responder's connection index, registers it (in
-// byIndex so the ClientFinished routes, and in bySource so ClientHello
-// retransmits route), and runs the handshake in its own goroutine.
-func (e *DatagramEndpoint) startResponder(src net.Addr, first inboundMsg) {
-	session, err := NewSession(RoleResponder)
-	if err != nil {
-		e.registry.releaseHalfOpen(src.String())
-		return
-	}
+	// Atomically resolve the bootstrap under one registry lock: route to an existing
+	// in-progress responder, or install this fresh session and start one, or drop at
+	// the cap. reserveSource registers the session in bySource as it claims the
+	// half-open slot - BEFORE the slow CH-KEM work in startResponder - so concurrent
+	// receive goroutines (the SO_REUSEPORT path) cannot both start a responder for the
+	// same new source: the loser sees the winner's session and routes to it.
 	ds := &datagramSession{
 		inbox:  make(chan inboundMsg, inboxCap),
 		recvCh: make(chan []byte, dataInboxCap),
 		closed: make(chan struct{}),
 	}
 	ds.setPeerAddr(src)
-	idx, err := e.registry.add(ds)
+	reserved, won := e.registry.reserveSource(src.String(), ds)
+	if !won {
+		if reserved != nil { // an existing responder owns this source: route the retransmit
+			trySend(reserved.inbox, in)
+		}
+		return // reserved == nil means the per-source cap is reached: drop
+	}
+	e.startResponder(src, ds, in)
+}
+
+// startResponder finishes bootstrapping the responder session ds (already registered
+// in bySource and holding a half-open slot, via reserveSource): it keys a session,
+// allocates the connection index, and runs the handshake in its own goroutine. On a
+// setup error it unwinds the source reservation and the half-open slot.
+func (e *DatagramEndpoint) startResponder(src net.Addr, ds *datagramSession, first inboundMsg) {
+	session, err := NewSession(RoleResponder)
 	if err != nil {
+		e.registry.removeSource(src.String())
 		e.registry.releaseHalfOpen(src.String())
 		return
 	}
-	e.registry.addSource(src.String(), ds)
+	idx, err := e.registry.add(ds)
+	if err != nil {
+		e.registry.removeSource(src.String())
+		e.registry.releaseHalfOpen(src.String())
+		return
+	}
 
 	l := &handshakeLoop{
 		ep:          e,

--- a/pkg/tunnel/dgram_perf_test.go
+++ b/pkg/tunnel/dgram_perf_test.go
@@ -138,14 +138,9 @@ func BenchmarkDatagramEndToEnd(b *testing.B) {
 	}
 }
 
-// dialFlows establishes n concurrent sessions into one shared responder endpoint,
-// each from its own initiator endpoint (socket). One initiator per flow is both
-// realistic (n clients = n sockets) and necessary: the responder bootstraps a new
-// handshake keyed by source address for the RecvIndex-0 ClientHello, so several
-// simultaneous handshakes from one source would collide at bootstrap (they are only
-// index-demuxed after establishment). The shared responder endpoint is the system
-// under test - its single Serve goroutine demuxes and drains all n flows. Returns
-// the n initiator conns paired with their responder sessions and a stop func.
+// dialFlows establishes n concurrent sessions into one shared single-socket
+// responder endpoint. See dialFlowsInto for the mechanics and why one initiator per
+// flow is used.
 func dialFlows(tb testing.TB, n int) (clients []*DatagramConn, servers []*datagramSession, stop func()) {
 	tb.Helper()
 	rxB, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
@@ -162,7 +157,20 @@ func dialFlows(tb testing.TB, n int) (clients []*DatagramConn, servers []*datagr
 		tb.Fatalf("responder endpoint: %v", err)
 	}
 	go epB.Serve()
+	return dialFlowsInto(tb, epB, rxB.LocalAddr(), n)
+}
 
+// dialFlowsInto dials n concurrent sessions into the already-serving responder
+// endpoint at dst, each from its own initiator endpoint (socket). One initiator per
+// flow is both realistic (n clients = n sockets) and necessary: the responder
+// bootstraps a new handshake keyed by source address for the RecvIndex-0
+// ClientHello, so several simultaneous handshakes from one source would collide at
+// bootstrap (they are only index-demuxed after establishment). The responder is the
+// system under test - its receive goroutine(s) demux and drain all n flows. Returns
+// the n initiator conns paired with their responder sessions and a stop func that
+// closes both the responder and the initiators.
+func dialFlowsInto(tb testing.TB, responder *DatagramEndpoint, dst net.Addr, n int) (clients []*DatagramConn, servers []*datagramSession, stop func()) {
+	tb.Helper()
 	initiators := make([]*DatagramEndpoint, 0, n)
 	type dialResult struct {
 		conn *DatagramConn
@@ -181,13 +189,13 @@ func dialFlows(tb testing.TB, n int) (clients []*DatagramConn, servers []*datagr
 		go epA.Serve()
 		initiators = append(initiators, epA)
 		go func() {
-			c, derr := DialDatagram(epA, rxB.LocalAddr())
+			c, derr := DialDatagram(epA, dst)
 			dialCh <- dialResult{c, derr}
 		}()
 	}
 	for range n {
 		select {
-		case ds := <-epB.acceptCh:
+		case ds := <-responder.acceptCh:
 			servers = append(servers, ds)
 		case <-time.After(10 * time.Second):
 			tb.Fatalf("only %d of %d responder sessions surfaced", len(servers), n)
@@ -204,7 +212,7 @@ func dialFlows(tb testing.TB, n int) (clients []*DatagramConn, servers []*datagr
 	}
 
 	stop = func() {
-		_ = epB.Close()
+		_ = responder.Close()
 		for _, ep := range initiators {
 			_ = ep.Close()
 		}
@@ -238,111 +246,143 @@ func BenchmarkDatagramEndToEndFlows(b *testing.B) {
 		b.Run(fmt.Sprintf("flows=%d", flows), func(b *testing.B) {
 			clients, servers, stop := dialFlows(b, flows)
 			defer stop()
-
-			payload := make([]byte, constants.DatagramMaxDataPayload)
-			const window = 16 // per-flow in-flight bound; well below dataInboxCap (64)
-			var received int64
-			stopDrain := make(chan struct{})
-			var drainWG sync.WaitGroup
-
-			// Per-flow credit semaphores (buffered channels), pre-filled to the window.
-			credits := make([]chan struct{}, flows)
-			for i := range credits {
-				credits[i] = make(chan struct{}, window)
-				for range window {
-					credits[i] <- struct{}{}
-				}
-			}
-
-			// One drainer per responder session: count the delivery and return a credit
-			// to its flow (non-blocking - the window cap means the channel can be full).
-			for i := range servers {
-				srv, cr := servers[i], credits[i]
-				drainWG.Add(1)
-				go func() {
-					defer drainWG.Done()
-					for {
-						select {
-						case <-srv.recvCh:
-							atomic.AddInt64(&received, 1)
-							select {
-							case cr <- struct{}{}:
-							default:
-							}
-						case <-srv.closed:
-							return
-						case <-stopDrain:
-							return
-						}
-					}
-				}()
-			}
-
-			// Watchdog: restore a credit per flow every 100ms so a kernel-dropped
-			// datagram (whose credit the drainer never returns) cannot permanently wedge
-			// a sender. Far below the real delivery rate, so it does not pace the bench.
-			go func() {
-				t := time.NewTicker(100 * time.Millisecond)
-				defer t.Stop()
-				for {
-					select {
-					case <-t.C:
-						for _, cr := range credits {
-							select {
-							case cr <- struct{}{}:
-							default:
-							}
-						}
-					case <-stopDrain:
-						return
-					}
-				}
-			}()
-
-			b.SetBytes(int64(len(payload)))
-			b.ReportAllocs()
-			b.ResetTimer()
-
-			// Spread b.N sends across the flows concurrently so all cores stay busy.
-			// Capture the first send error atomically rather than calling b.Errorf from
-			// these goroutines: testing.B is not safe for concurrent Errorf, and CI runs
-			// under -race. Report it on the main goroutine after the senders join.
-			var wg sync.WaitGroup
-			var sendErr atomic.Value
-			per := b.N / flows
-			for i := range clients {
-				count := per
-				if i == len(clients)-1 {
-					count = b.N - per*(flows-1) // remainder on the last flow
-				}
-				c, cr := clients[i], credits[i]
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					for range count {
-						<-cr
-						if err := c.Send(payload); err != nil {
-							sendErr.CompareAndSwap(nil, err)
-							return
-						}
-					}
-				}()
-			}
-			wg.Wait()
-			elapsed := b.Elapsed()
-			b.StopTimer()
-			close(stopDrain)
-			drainWG.Wait() // do not leak drainers into the next sub-benchmark
-
-			if err, _ := sendErr.Load().(error); err != nil {
-				b.Fatalf("send: %v", err)
-			}
-			if secs := elapsed.Seconds(); secs > 0 {
-				got := atomic.LoadInt64(&received)
-				b.ReportMetric(float64(got*int64(len(payload)))/secs/1e6, "recv-MB/s")
-			}
+			runFlowGoodput(b, clients, servers)
 		})
 	}
+}
+
+// runFlowGoodput drives the closed-loop aggregate-goodput measurement over the
+// established clients/servers: each flow sends b.N/flows datagrams paced by a
+// per-flow credit window the drainer refills on delivery, with a watchdog top-up so
+// a kernel drop cannot wedge a sender. SetBytes reports the send rate; recv-MB/s
+// reports delivered goodput over the same wall-clock. Shared by the single-socket
+// (BenchmarkDatagramEndToEndFlows) and SO_REUSEPORT (BenchmarkDatagramListenScale)
+// benchmarks so they measure identically.
+func runFlowGoodput(b *testing.B, clients []*DatagramConn, servers []*datagramSession) {
+	b.Helper()
+	flows := len(clients)
+	payload := make([]byte, constants.DatagramMaxDataPayload)
+	const window = 16 // per-flow in-flight bound; well below dataInboxCap (64)
+	var received int64
+	stopDrain := make(chan struct{})
+	var drainWG sync.WaitGroup
+
+	// Per-flow credit semaphores (buffered channels), pre-filled to the window.
+	credits := make([]chan struct{}, flows)
+	for i := range credits {
+		credits[i] = make(chan struct{}, window)
+		for range window {
+			credits[i] <- struct{}{}
+		}
+	}
+
+	// One drainer per responder session: count the delivery and return a credit to
+	// its flow (non-blocking - the window cap means the channel can be full).
+	for i := range servers {
+		srv, cr := servers[i], credits[i]
+		drainWG.Add(1)
+		go func() {
+			defer drainWG.Done()
+			for {
+				select {
+				case <-srv.recvCh:
+					atomic.AddInt64(&received, 1)
+					select {
+					case cr <- struct{}{}:
+					default:
+					}
+				case <-srv.closed:
+					return
+				case <-stopDrain:
+					return
+				}
+			}
+		}()
+	}
+
+	// Watchdog: restore a credit per flow every 100ms so a kernel-dropped datagram
+	// (whose credit the drainer never returns) cannot permanently wedge a sender. Far
+	// below the real delivery rate, so it does not pace the bench.
+	go func() {
+		t := time.NewTicker(100 * time.Millisecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				for _, cr := range credits {
+					select {
+					case cr <- struct{}{}:
+					default:
+					}
+				}
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Spread b.N sends across the flows concurrently so all cores stay busy. Capture
+	// the first send error atomically rather than calling b.Errorf from these
+	// goroutines: testing.B is not safe for concurrent Errorf, and CI runs under
+	// -race. Report it on the main goroutine after the senders join.
+	var wg sync.WaitGroup
+	var sendErr atomic.Value
+	per := b.N / flows
+	for i := range clients {
+		count := per
+		if i == len(clients)-1 {
+			count = b.N - per*(flows-1) // remainder on the last flow
+		}
+		c, cr := clients[i], credits[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range count {
+				<-cr
+				if err := c.Send(payload); err != nil {
+					sendErr.CompareAndSwap(nil, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := b.Elapsed()
+	b.StopTimer()
+	close(stopDrain)
+	drainWG.Wait() // do not leak drainers past this measurement
+
+	if err, _ := sendErr.Load().(error); err != nil {
+		b.Fatalf("send: %v", err)
+	}
+	if secs := elapsed.Seconds(); secs > 0 {
+		got := atomic.LoadInt64(&received)
+		b.ReportMetric(float64(got*int64(len(payload)))/secs/1e6, "recv-MB/s")
+	}
+}
+
+// benchListenFlows runs the aggregate-goodput measurement against a ListenDatagram
+// responder configured with the given SO_REUSEPORT socket count, so the benchmark
+// shows how aggregate throughput scales with receive sockets.
+func benchListenFlows(b *testing.B, sockets, flows int) {
+	b.Helper()
+	responder, err := ListenDatagram("udp", "127.0.0.1:0", WithReceiveSockets(sockets))
+	if err != nil {
+		b.Fatalf("ListenDatagram: %v", err)
+	}
+	for _, c := range append([]net.PacketConn{responder.conn}, responder.extraConns...) {
+		if uc, ok := c.(*net.UDPConn); ok {
+			_ = uc.SetReadBuffer(8 << 20)
+		}
+	}
+	go responder.Serve()
+	clients, servers, stop := dialFlowsInto(b, responder, responder.conn.LocalAddr(), flows)
+	defer stop()
+	runFlowGoodput(b, clients, servers)
 }
 
 // BenchmarkDatagramRecvBacklog measures the receive path under a real backlog: a

--- a/pkg/tunnel/dgram_reuseport_linux.go
+++ b/pkg/tunnel/dgram_reuseport_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package tunnel
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// listenReusePort opens n UDP sockets all bound to the same address via
+// SO_REUSEPORT, so the kernel load-balances inbound datagrams across them by 4-tuple
+// flow hash. The first socket binds the requested addr (resolving a :0 port to a
+// concrete one); the remaining sockets bind that resolved addr so they share it. On
+// any error it closes the sockets already opened and returns the error, so there is
+// no partially-built endpoint and no leaked fd.
+func listenReusePort(network, addr string, n int) ([]*net.UDPConn, error) {
+	lc := net.ListenConfig{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var serr error
+			if cerr := c.Control(func(fd uintptr) {
+				// SO_REUSEPORT lets multiple sockets bind the same addr and load-balances
+				// across them; SO_REUSEADDR eases rebind. Both must be set before bind,
+				// which is exactly when this control hook runs.
+				if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+					serr = err
+					return
+				}
+				serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+			}); cerr != nil {
+				return cerr
+			}
+			return serr
+		},
+	}
+
+	conns := make([]*net.UDPConn, 0, n)
+	bindAddr := addr
+	for range n {
+		pc, err := lc.ListenPacket(context.Background(), network, bindAddr)
+		if err != nil {
+			for _, c := range conns {
+				_ = c.Close()
+			}
+			return nil, err
+		}
+		uc := pc.(*net.UDPConn)
+		conns = append(conns, uc)
+		// After the first bind, pin the remaining sockets to the now-concrete port so
+		// a :0 request resolves once and all n share one addr:port.
+		bindAddr = uc.LocalAddr().String()
+	}
+	return conns, nil
+}

--- a/pkg/tunnel/dgram_reuseport_other.go
+++ b/pkg/tunnel/dgram_reuseport_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package tunnel
+
+import (
+	"context"
+	"net"
+)
+
+// listenReusePort opens a single UDP socket on platforms without portable
+// SO_REUSEPORT load-balancing semantics, so ListenDatagram degrades to one receiver
+// (still correct, just not parallel). It ignores n. No golang.org/x/sys import.
+func listenReusePort(network, addr string, _ int) ([]*net.UDPConn, error) {
+	var lc net.ListenConfig
+	pc, err := lc.ListenPacket(context.Background(), network, addr)
+	if err != nil {
+		return nil, err
+	}
+	return []*net.UDPConn{pc.(*net.UDPConn)}, nil
+}

--- a/pkg/tunnel/dgram_reuseport_test.go
+++ b/pkg/tunnel/dgram_reuseport_test.go
@@ -1,0 +1,187 @@
+package tunnel
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReserveSourceBootstrapRace drives two concurrent bootstrap ClientHellos for
+// the SAME source through routeDatagram from two goroutines (what the SO_REUSEPORT
+// parallel-receive path does when the kernel hashes a ClientHello and its retransmit
+// to different sockets). Exactly one responder session must be created and exactly
+// one half-open slot claimed - the regression test for the reserveSource fix. On the
+// old separate-lock deliverHandshake this fails (two sessions, leaked slot) under
+// -race / repetition.
+func TestReserveSourceBootstrapRace(t *testing.T) {
+	for attempt := 0; attempt < 50; attempt++ {
+		ep := mustEndpoint(t, newBlackholeConn())
+		src := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 40000}
+		frame := clientHelloFrame(t, 0x1234, 0, 64, 64, nil)
+
+		var wg sync.WaitGroup
+		for range 2 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = ep.routeDatagram(src, append([]byte(nil), frame...))
+			}()
+		}
+		wg.Wait()
+
+		// Exactly one responder session and one half-open slot for the source.
+		if got := ep.registry.count(); got != 1 {
+			t.Fatalf("attempt %d: created %d responder sessions for one source, want 1", attempt, got)
+		}
+		if got := ep.registry.halfOpenLoad(); got != 1 {
+			t.Fatalf("attempt %d: half-open count = %d, want 1 (a leaked or double slot)", attempt, got)
+		}
+		_ = ep.Close()
+	}
+}
+
+// blackholeConn is a net.PacketConn whose ReadFrom blocks until close and whose
+// WriteTo discards. The bootstrap-race test drives routeDatagram directly and never
+// runs Serve, but startResponder's handshake goroutine may try to send a
+// ServerHello; this swallows it without a real socket.
+type blackholeConn struct{ closed chan struct{} }
+
+func newBlackholeConn() *blackholeConn { return &blackholeConn{closed: make(chan struct{})} }
+
+func (c *blackholeConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	<-c.closed
+	return 0, nil, net.ErrClosed
+}
+func (c *blackholeConn) WriteTo(p []byte, _ net.Addr) (int, error) { return len(p), nil }
+func (c *blackholeConn) Close() error {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return nil
+}
+func (c *blackholeConn) LocalAddr() net.Addr              { return &net.UDPAddr{} }
+func (c *blackholeConn) SetDeadline(time.Time) error      { return nil }
+func (c *blackholeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *blackholeConn) SetWriteDeadline(time.Time) error { return nil }
+
+// TestListenDatagram checks the constructor works on every platform: it returns a
+// usable endpoint bound to a concrete port, honoring WithReceiveSockets. On Linux it
+// opens multiple SO_REUSEPORT sockets sharing the port; elsewhere it degrades to one
+// (still usable). It does not assert the socket count (that is platform-specific and
+// covered by the Linux e2e test); it asserts construction + a real bound address.
+func TestListenDatagram(t *testing.T) {
+	ep, err := ListenDatagram("udp", "127.0.0.1:0", WithReceiveSockets(4))
+	if err != nil {
+		t.Fatalf("ListenDatagram: %v", err)
+	}
+	defer func() { _ = ep.Close() }()
+
+	addr := ep.conn.LocalAddr().(*net.UDPAddr)
+	if addr.Port == 0 {
+		t.Fatal("ListenDatagram did not resolve an ephemeral port")
+	}
+	// Every receive socket (primary + extras) must share that resolved port.
+	for i, c := range ep.extraConns {
+		if got := c.LocalAddr().(*net.UDPAddr).Port; got != addr.Port {
+			t.Fatalf("extra socket %d on port %d, want shared %d", i, got, addr.Port)
+		}
+	}
+}
+
+// TestListenDatagramEndToEnd dials several concurrent flows into a ListenDatagram
+// responder (parallel receive across sockets where available) and asserts every
+// handshake completes and data round-trips both ways - proving concurrent
+// routeDatagram over the fan-out receive path is correct.
+func TestListenDatagramEndToEnd(t *testing.T) {
+	server, err := ListenDatagram("udp", "127.0.0.1:0", WithReceiveSockets(4))
+	if err != nil {
+		t.Fatalf("ListenDatagram: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+	go server.Serve()
+	dst := server.conn.LocalAddr()
+
+	const flows = 6
+	type result struct {
+		conn *DatagramConn
+		err  error
+	}
+	dialCh := make(chan result, flows)
+	initiators := make([]*DatagramEndpoint, 0, flows)
+	for range flows {
+		rx, lerr := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		if lerr != nil {
+			t.Fatalf("listen initiator: %v", lerr)
+		}
+		ep, eerr := NewDatagramEndpoint(rx)
+		if eerr != nil {
+			t.Fatalf("initiator endpoint: %v", eerr)
+		}
+		go ep.Serve()
+		initiators = append(initiators, ep)
+		go func() {
+			c, derr := DialDatagram(ep, dst)
+			dialCh <- result{c, derr}
+		}()
+	}
+	defer func() {
+		for _, ep := range initiators {
+			_ = ep.Close()
+		}
+	}()
+
+	clients := make([]*DatagramConn, 0, flows)
+	servers := make([]*datagramSession, 0, flows)
+	for range flows {
+		select {
+		case ds := <-server.acceptCh:
+			servers = append(servers, ds)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d responder sessions surfaced", len(servers), flows)
+		}
+		select {
+		case r := <-dialCh:
+			if r.err != nil {
+				t.Fatalf("dial: %v", r.err)
+			}
+			clients = append(clients, r.conn)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d dials completed", len(clients), flows)
+		}
+	}
+
+	// Pair each client with ITS server session: concurrent dials complete and
+	// surface in arbitrary order, so the i-th client is not the i-th accepted
+	// session. A client's peerIndex is the responder session's local index (echoed
+	// back during the handshake), so match on that.
+	byIndex := make(map[uint32]*datagramSession, len(servers))
+	for _, srv := range servers {
+		byIndex[srv.index] = srv
+	}
+	for _, c := range clients {
+		srv := byIndex[c.ds.peerIndex]
+		if srv == nil {
+			t.Fatalf("no responder session for client peerIndex %d", c.ds.peerIndex)
+		}
+		assertDataRoundTrip(t, c.Session(), srv.session)
+		assertDataRoundTrip(t, srv.session, c.Session())
+	}
+}
+
+// BenchmarkDatagramListenScale measures aggregate delivered goodput into a
+// ListenDatagram responder as the receive-socket count varies. On Linux the kernel
+// load-balances across the sockets, so this shows the parallel-receive scaling curve
+// against the Phase-2 single-goroutine plateau; elsewhere it degrades to one socket.
+// Run on Linux with -benchmem (and a hard -timeout). It reuses the flow harness from
+// dgram_perf_test.go.
+func BenchmarkDatagramListenScale(b *testing.B) {
+	for _, sockets := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("sockets=%d", sockets), func(b *testing.B) {
+			benchListenFlows(b, sockets, 8)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `ListenDatagram`, which spreads the datagram receive path across multiple SO_REUSEPORT sockets so demux and AEAD-open scale across cores. Also fixes a handshake-bootstrap concurrency race that the parallel receive path exposes. `NewDatagramEndpoint` and every existing single-socket path are untouched.

## Why

Phase 2 measured the aggregate-throughput ceiling: one `Serve` goroutine does all demux + AEAD-open on a single core, so aggregate goodput plateaus around 4 flows (the CPU profile is ~35% AES + ~30% syscalls, all on one core). Cutting syscalls (GSO/GRO) would not lift a CPU-bound ceiling; running the receive path on multiple cores does. SO_REUSEPORT is how high-performance UDP servers (and quic-go) scale, and it keeps Phase 1's zero-copy receive (no shared funnel).

## How

- `ListenDatagram(network, addr, opts...)` opens N UDP sockets bound to one address via SO_REUSEPORT (N = `WithReceiveSockets`, default `min(GOMAXPROCS, DatagramMaxReceiveSockets=8)`); the kernel load-balances inbound datagrams across them by 4-tuple flow hash. `Serve` runs one receive goroutine per socket; all dispatch into the shared, already-concurrency-safe `routeDatagram`. The send path, cookie RETRY, and handshake/rekey flights keep using one designated socket (all N share the bind addr:port, so the peer sees one source). `pkg/tunnel/dgram_reuseport_linux.go` sets the sockopt via `net.ListenConfig.Control`; `dgram_reuseport_other.go` degrades to one socket with no `x/sys` import (same build-tag split as `dgram_batch`).
- Concurrency fix: fan-out makes `routeDatagram` run from many goroutines, exposing a check-then-act race in the RecvIndex-0 bootstrap (`deliverHandshake` did lookup-source -> claim-half-open -> start-responder across three separate lock acquisitions, so two concurrent ClientHellos for one new source could each start a responder). The new `connRegistry.reserveSource` resolves the bootstrap under one lock: it returns the existing in-progress responder, or installs this session in `bySource` as it claims the half-open slot (before the slow CH-KEM work), so the losing goroutine routes to the winner. Single-socket behavior is identical.

## Concurrency audit (in the commit body / plan)

DATA path, rekey cache, replay window, reassembler: all already mutex-guarded and safe under concurrent `routeDatagram`. The bootstrap was the one unsafe check-then-act, now fixed and regression-tested.

## Measured (Linux container, arm64 - indicative; a VM mutes the gain, direction is the point)

Aggregate delivered goodput at 8 flows by receive-socket count: 1 -> ~300 MB/s, 4 -> ~398, 8 -> ~456 MB/s. Lifts the Phase-2 single-goroutine plateau (which capped ~320-370 and dipped at 8 flows); scales further on bare metal.

## Tests

- `TestReserveSourceBootstrapRace` - drives two concurrent same-source ClientHellos and asserts exactly one responder + one half-open slot (fails on the old separate-lock code under `-race`).
- `TestListenDatagram` / `TestListenDatagramEndToEnd` - construction + multi-flow handshake/data round-trip over the fan-out receiver (clients paired to servers by connection index, since concurrent dials surface out of order).
- `BenchmarkDatagramListenScale` - the socket-count scaling curve.

Full repo green under `-race` (the headline gate for concurrent receive, verified on Linux where the sockets are truly parallel); `golangci-lint` (Linux container) and `gofmt` clean; builds on linux/darwin/windows.

## Out of scope / future

GSO/GRO (`UDP_SEGMENT`/`UDP_GRO`) is a complementary single-flow syscall optimization, documented on the roadmap; registry lock-striping only if profiling shows the shared registry mutex becomes the next ceiling.
