### PR TITLE
build the datagram responder session only after admitting its source

### DIFF
--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -115,11 +115,11 @@ func (ds *datagramSession) teardown(r *connRegistry) {
 }
 
 // connRegistry maps the random connection indices we assign to their sessions
-// and provides per-source half-open (un-established) accounting. The handshake
-// FSM gates new half-open sessions through tryAddHalfOpen (releasing on
-// establishment or teardown); until that is wired, the reassembler's global and
-// per-source caps are the active pre-auth memory bounds. A future stateless
-// cookie/retry exchange removes the spoofed-source vector entirely.
+// and provides per-source half-open (un-established) accounting. The bootstrap
+// path admits new half-open responder sessions through reserveSource and releases
+// them on establishment or teardown; that per-source half-open cap, the
+// reassembler's global and per-source caps, and the stateless cookie gate are the
+// pre-auth memory bounds against spoofed sources.
 type connRegistry struct {
 	mu            sync.Mutex
 	byIndex       map[uint32]*datagramSession
@@ -227,6 +227,13 @@ func (r *connRegistry) idleSince(cutoffNanos int64) []*datagramSession {
 func (r *connRegistry) tryAddHalfOpen(source string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.addHalfOpenLocked(source)
+}
+
+// addHalfOpenLocked increments the half-open count for source, or returns false if
+// the per-source cap is already reached. The caller must hold r.mu. It is the single
+// admission check shared by tryAddHalfOpen and reserveSource.
+func (r *connRegistry) addHalfOpenLocked(source string) bool {
 	if r.halfOpen[source] >= constants.DatagramMaxHalfOpenPerSource {
 		return false
 	}
@@ -280,29 +287,30 @@ func (r *connRegistry) knownSource(index uint32, src string) bool {
 // reserveSource makes the bootstrap decision for a RecvIndex-0 ClientHello from
 // source atomically under one lock, so concurrent receive goroutines (the
 // SO_REUSEPORT parallel-receive path) cannot both start a responder for the same new
-// source. The caller passes a freshly-built (not-yet-keyed) session to install if
-// source is new. It returns:
-//   - (ds, true): source was new and admitted - the passed session is now registered
+// source. build constructs the not-yet-keyed session to install, and runs ONLY when
+// source is admitted - so a retransmit that loses the race or a ClientHello past the
+// cap costs no session allocation. It returns:
+//   - (ds, true): source was new and admitted - the built session is now registered
 //     in bySource and a half-open slot is claimed; the caller MUST run startResponder
 //     with this session and release the slot on failure. Registering in bySource
 //     here (not later, after the slow CH-KEM work in startResponder) is what closes
 //     the window where a second goroutine could also start a responder.
 //   - (existing, false): a responder for source already exists (this goroutine raced
 //     a retransmit, or the kernel hashed two copies to two sockets); the caller
-//     routes the ClientHello to existing and discards its freshly-built session.
-//   - (nil, false): the per-source half-open cap is reached; the caller drops.
-func (r *connRegistry) reserveSource(source string, fresh *datagramSession) (ds *datagramSession, reserved bool) {
+//     routes the ClientHello to existing. build did not run.
+//   - (nil, false): the per-source half-open cap is reached; the caller drops. build
+//     did not run.
+func (r *connRegistry) reserveSource(source string, build func() *datagramSession) (ds *datagramSession, reserved bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if existing := r.bySource[source]; existing != nil {
 		return existing, false
 	}
-	if r.halfOpen[source] >= constants.DatagramMaxHalfOpenPerSource {
+	if !r.addHalfOpenLocked(source) {
 		return nil, false
 	}
+	fresh := build()
 	r.bySource[source] = fresh
-	r.halfOpen[source]++
-	r.halfOpenTotal++
 	return fresh, true
 }
 

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -61,25 +61,29 @@ func (e *DatagramEndpoint) deliverHandshake(src net.Addr, h protocol.DatagramHan
 		return
 	}
 	// Atomically resolve the bootstrap under one registry lock: route to an existing
-	// in-progress responder, or install this fresh session and start one, or drop at
-	// the cap. reserveSource registers the session in bySource as it claims the
+	// in-progress responder, or build and install a fresh session and start one, or
+	// drop at the cap. reserveSource registers the session in bySource as it claims the
 	// half-open slot - BEFORE the slow CH-KEM work in startResponder - so concurrent
 	// receive goroutines (the SO_REUSEPORT path) cannot both start a responder for the
-	// same new source: the loser sees the winner's session and routes to it.
-	ds := &datagramSession{
-		inbox:  make(chan inboundMsg, inboxCap),
-		recvCh: make(chan []byte, dataInboxCap),
-		closed: make(chan struct{}),
-	}
-	ds.setPeerAddr(src)
-	reserved, won := e.registry.reserveSource(src.String(), ds)
+	// same new source: the loser sees the winner's session and routes to it. The
+	// session is built only when the source is admitted, so a lost retransmit or a
+	// capped ClientHello allocates nothing.
+	reserved, won := e.registry.reserveSource(src.String(), func() *datagramSession {
+		ds := &datagramSession{
+			inbox:  make(chan inboundMsg, inboxCap),
+			recvCh: make(chan []byte, dataInboxCap),
+			closed: make(chan struct{}),
+		}
+		ds.setPeerAddr(src)
+		return ds
+	})
 	if !won {
 		if reserved != nil { // an existing responder owns this source: route the retransmit
 			trySend(reserved.inbox, in)
 		}
 		return // reserved == nil means the per-source cap is reached: drop
 	}
-	e.startResponder(src, ds, in)
+	e.startResponder(src, reserved, in)
 }
 
 // startResponder finishes bootstrapping the responder session ds (already registered

--- a/pkg/tunnel/dgram_reuseport_test.go
+++ b/pkg/tunnel/dgram_reuseport_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
 )
 
 // TestReserveSourceBootstrapRace drives two concurrent bootstrap ClientHellos for
@@ -67,6 +69,59 @@ func (c *blackholeConn) LocalAddr() net.Addr              { return &net.UDPAddr{
 func (c *blackholeConn) SetDeadline(time.Time) error      { return nil }
 func (c *blackholeConn) SetReadDeadline(time.Time) error  { return nil }
 func (c *blackholeConn) SetWriteDeadline(time.Time) error { return nil }
+
+// TestReserveSourceOutcomes exercises reserveSource's three outcomes directly: admit
+// a new source, route a second ClientHello for an in-progress source to the existing
+// responder, and drop once the per-source half-open cap is reached. It also asserts
+// the build closure runs ONLY on the admit path, so a lost retransmit or a capped
+// ClientHello allocates no session. This is the production bootstrap admission path
+// the SO_REUSEPORT fan-out relies on; the tryAddHalfOpen-based tests no longer cover
+// it since reserveSource owns the decision.
+//
+// The cap branch is defensive: in production reserveSource is the only half-open
+// incrementer and it dedups per source (the existing-responder check fires first), so
+// one source tops out at a single in-progress responder and never reaches the cap on
+// its own. The test fills the slots directly via tryAddHalfOpen to reach that branch.
+func TestReserveSourceOutcomes(t *testing.T) {
+	r := newConnRegistry()
+	builds := 0
+	build := func() *datagramSession { builds++; return &datagramSession{} }
+
+	// New source: admitted, build runs once, one slot claimed.
+	const src = "203.0.113.7:51820"
+	first, won := r.reserveSource(src, build)
+	if !won || first == nil {
+		t.Fatalf("new source: got (%v, %v), want admitted", first, won)
+	}
+	if builds != 1 || r.halfOpenLoad() != 1 {
+		t.Fatalf("after admit: builds=%d halfOpen=%d, want 1 and 1", builds, r.halfOpenLoad())
+	}
+
+	// Same in-progress source: routes to the existing responder, no build, no extra slot.
+	again, won := r.reserveSource(src, build)
+	if won || again != first {
+		t.Fatalf("retransmit: got (%v, %v), want the existing session and won=false", again, won)
+	}
+	if builds != 1 || r.halfOpenLoad() != 1 {
+		t.Fatalf("after retransmit: builds=%d halfOpen=%d, want unchanged 1 and 1", builds, r.halfOpenLoad())
+	}
+
+	// Capped source: fill its half-open slots, then reserveSource must drop without building.
+	const capped = "198.51.100.4:51820"
+	for i := 0; i < constants.DatagramMaxHalfOpenPerSource; i++ {
+		if !r.tryAddHalfOpen(capped) {
+			t.Fatalf("slot %d for capped source should be admitted (cap %d)", i, constants.DatagramMaxHalfOpenPerSource)
+		}
+	}
+	buildsBefore := builds
+	ds, won := r.reserveSource(capped, build)
+	if won || ds != nil {
+		t.Fatalf("capped source: got (%v, %v), want (nil, false)", ds, won)
+	}
+	if builds != buildsBefore {
+		t.Fatalf("build ran on the capped path (%d -> %d), want no allocation", buildsBefore, builds)
+	}
+}
 
 // TestListenDatagram checks the constructor works on every platform: it returns a
 // usable endpoint bound to a concrete port, honoring WithReceiveSockets. On Linux it


### PR DESCRIPTION
## What

Follow-up cleanup to the SO_REUSEPORT parallel-receive change (0f71728), from a code review of the datagram bootstrap path.

- `reserveSource` now takes a `build func() *datagramSession` closure that runs only on the admit path. A ClientHello retransmit that loses the bootstrap race, or one past the per-source half-open cap, no longer allocates a throwaway session (two channels). Retransmits and SO_REUSEPORT dual-delivery are the common duplicate case, so this drops a pure-waste allocation on the hot path.
- Extracted `addHalfOpenLocked` as the single per-source admission check that `tryAddHalfOpen` and `reserveSource` both call, so the cap logic has one source of truth instead of two copies that could drift. `tryAddHalfOpen` is now a thin lock-taking wrapper the tests use.
- Added `TestReserveSourceOutcomes` covering the three `reserveSource` results (admit, route-to-existing, drop-at-cap) and asserting `build` runs only on admit.
- Fixed the `connRegistry` doc comment that still named `tryAddHalfOpen` as the bootstrap gate.

## Why

The review flagged a wasted allocation on duplicate ClientHellos and duplicated cap logic between `tryAddHalfOpen` (now production-unused) and `reserveSource`. This consolidates both.

## Verification

- `go vet ./pkg/tunnel/` clean
- `go test -race ./pkg/tunnel/` green
- `GOOS=linux GOARCH=amd64 go build ./pkg/tunnel/` builds the SO_REUSEPORT path

## Note

The per-source half-open cap (`DatagramMaxHalfOpenPerSource = 8`) is effectively unreachable on the bootstrap path: `reserveSource` dedups per source, so any one source tops out at a single in-progress responder. This predates this change. A follow-up will repurpose that constant into a meaningful bound.
