### PR TITLE
enforce and autoscale the datagram half-open ceiling

### DIFF
--- a/docs/datagram-dos.md
+++ b/docs/datagram-dos.md
@@ -38,10 +38,20 @@ address), so it cannot proceed. This is the QUIC `RETRY` posture.
 - **Load-gated.** The gate is inactive under normal load, so honest handshakes add
   zero round trips. It engages only when the endpoint is under pressure, defined as
   either the in-progress reassembly source count **or** the global half-open count
-  crossing `DatagramCookiePressureHighWater` (half of the hard half-open cap). The
+  crossing the cookie-pressure water-mark (half of the half-open ceiling). The
   two signals are complementary: reassembler occupancy catches the
   partial-fragment flood, the half-open count catches a completed-ClientHello /
   CH-KEM flood.
+- **Hard half-open ceiling.** The cookie demand is a soft throttle; behind it,
+  `reserveSource` enforces a hard ceiling on concurrent half-open (un-established)
+  responder sessions. Once `halfOpenTotal` reaches the ceiling, a `ClientHello` from
+  a **new** source is dropped (an in-progress source already holding a slot is
+  exempt, so retransmits still route). This bounds the goroutines and CH-KEM state a
+  source past the cookie gate can pin. The ceiling **autoscales** with core count -
+  `clamp(GOMAXPROCS * 256, 1024, 8192)` - so a busy multi-core server gets
+  proportional headroom while a small host stays bounded; the reassembler's source
+  cap and the cookie water-mark (ceiling/2) track it so the soft and hard signals
+  stay proportional. `WithMaxHalfOpen(n)` pins a fixed ceiling for a known deployment.
 - **Pre-reassembly.** The gate sits in `routeDatagram` *before* `reasm.Add`, so a
   rejected frame allocates no reassembly buffer and triggers no CH-KEM. Verifying a
   cookie (one HMAC over ~40 bytes) is far cheaper than the buffer it prevents.

--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -116,7 +116,8 @@ needs no wire change.
 Amplification is inherently low: the ~1.7 KB ClientHello must be fully received
 and reassembled before the comparable ServerHello is sent (response:request ≈
 1:1, not an amplifier). The implementation additionally reuses the existing rate
-limiters and caps concurrent half-open handshakes per source and overall. A
+limiters and enforces a hard, core-scaled ceiling on concurrent half-open
+handshakes (`reserveSource` drops new sources once the ceiling is reached). A
 load-gated stateless cookie closes the residual spoofed-source state-exhaustion
 gap and enforces a strict anti-amplification bound, and a session follows a
 roaming peer only on an authenticated, replay-fresh frame; see
@@ -137,6 +138,47 @@ anti-amplification bound, since a RETRY is only ever sent when it is no larger t
 the triggering datagram. The receiver tolerates padding unconditionally, so a
 padding peer interoperates with a non-padding one; for full effect enable it on both
 ends.
+
+## Scaling and configuration
+
+A single receive goroutine demuxing and AEAD-opening every datagram is the
+aggregate-throughput ceiling on a busy multi-session server. `ListenDatagram`
+opens N `SO_REUSEPORT` sockets bound to one address; the kernel load-balances
+inbound datagrams across them by flow hash and `Serve` runs one receive goroutine
+per socket, so demux and AEAD-open spread across cores. On platforms without
+`SO_REUSEPORT` it transparently degrades to one socket. `NewDatagramEndpoint`
+(single socket) is unchanged.
+
+```go
+ep, err := tunnel.ListenDatagram("udp", "0.0.0.0:51820")
+if err != nil { /* ... */ }
+go ep.Serve()
+```
+
+- `WithReceiveSockets(n)` sets the `SO_REUSEPORT` socket count (clamped to
+  `[1, DatagramMaxReceiveSockets]`); the default is `min(GOMAXPROCS,
+  DatagramMaxReceiveSockets)`.
+- `WithMaxHalfOpen(n)` pins the concurrent half-open handshake ceiling. The default
+  autoscales with core count - `clamp(GOMAXPROCS * 256, 1024, 8192)` - and the
+  cookie-pressure water-mark tracks at half of it; see
+  [datagram-dos.md](datagram-dos.md).
+
+### High-assurance deployment example
+
+A conservative deployment can pin the capacity/DoS knobs and enable handshake
+padding:
+
+```go
+ep, _ := tunnel.ListenDatagram("udp", addr,
+    tunnel.WithMaxHalfOpen(1024),  // pinned, predictable half-open budget
+    tunnel.WithHandshakePadding(), // size-uniform handshakes (traffic analysis)
+)
+```
+
+This only pins capacity and DoS-posture knobs. The cryptography (ML-KEM-1024 +
+X25519 CH-KEM) is fixed and already at the high-assurance tier, matching the
+conservative posture BSI / US-federal guidance favors. It is **not** a certified
+BSI/FIPS profile; for FIPS 140-3 build mode see [FIPS.md](FIPS.md).
 
 ## Out of scope (future)
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -223,22 +223,19 @@ const (
 	// reaped (there is no FIN over UDP; close is best-effort).
 	DatagramIdleTimeoutSeconds = 120
 
-	// DatagramMaxHalfOpenPerSource caps concurrent half-open (un-established)
-	// handshakes from a single source address.
-	DatagramMaxHalfOpenPerSource = 8
-
-	// DatagramMaxHalfOpenTotal caps concurrent half-open handshakes across all
-	// sources.
-	DatagramMaxHalfOpenTotal = 1024
-
-	// DatagramCookiePressureHighWater is the load at which the datagram endpoint
-	// starts demanding a stateless return-routability cookie from new sources
-	// before committing handshake state (the QUIC-style anti-DoS posture). It is
-	// compared against both the in-progress reassembly source count and the global
-	// half-open count; either crossing it flips the endpoint into cookie-required
-	// mode. Set to half of DatagramMaxHalfOpenTotal so cookies engage well before
-	// the hard caps are reached, leaving headroom for the verified path.
-	DatagramCookiePressureHighWater = DatagramMaxHalfOpenTotal / 2
+	// The concurrent half-open (un-established) handshake ceiling autoscales with
+	// core count: an endpoint's effective cap is clamp(GOMAXPROCS * PerCore, Floor,
+	// Ceiling), and the cookie-pressure water-mark is half of it. A busy multi-core
+	// server (the SO_REUSEPORT receive path) gets proportional headroom while a small
+	// host stays bounded. WithMaxHalfOpen overrides the autoscaled default.
+	//
+	// DatagramMaxHalfOpenFloor is the minimum ceiling (and the NewReassembler default
+	// source cap); DatagramMaxHalfOpenPerCore is the per-core allotment;
+	// DatagramMaxHalfOpenCeiling is the hard upper bound that keeps a high-core host
+	// from committing to an unbounded half-open table.
+	DatagramMaxHalfOpenFloor   = 1024
+	DatagramMaxHalfOpenPerCore = 256
+	DatagramMaxHalfOpenCeiling = 8192
 
 	// DatagramReplayWindowBits is the width of the datagram anti-replay window.
 	DatagramReplayWindowBits = 1024

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -115,24 +115,26 @@ func (ds *datagramSession) teardown(r *connRegistry) {
 }
 
 // connRegistry maps the random connection indices we assign to their sessions
-// and provides per-source half-open (un-established) accounting. The bootstrap
-// path admits new half-open responder sessions through reserveSource and releases
-// them on establishment or teardown; that per-source half-open cap, the
-// reassembler's global and per-source caps, and the stateless cookie gate are the
-// pre-auth memory bounds against spoofed sources.
+// and provides half-open (un-established) accounting. The bootstrap path admits new
+// half-open responder sessions through reserveSource and releases them on
+// establishment or teardown; the global half-open ceiling (maxHalfOpen) it enforces,
+// the reassembler's caps, and the stateless cookie gate are the pre-auth memory
+// bounds against spoofed sources.
 type connRegistry struct {
 	mu            sync.Mutex
 	byIndex       map[uint32]*datagramSession
 	bySource      map[string]*datagramSession // in-progress responder handshakes, keyed by source
 	halfOpen      map[string]int              // source identity -> count of un-established sessions
 	halfOpenTotal int                         // sum of halfOpen across all sources (cookie-pressure signal)
+	maxHalfOpen   int                         // hard ceiling on halfOpenTotal; reserveSource drops new sources at it
 }
 
-func newConnRegistry() *connRegistry {
+func newConnRegistry(maxHalfOpen int) *connRegistry {
 	return &connRegistry{
-		byIndex:  make(map[uint32]*datagramSession),
-		bySource: make(map[string]*datagramSession),
-		halfOpen: make(map[string]int),
+		byIndex:     make(map[uint32]*datagramSession),
+		bySource:    make(map[string]*datagramSession),
+		halfOpen:    make(map[string]int),
+		maxHalfOpen: maxHalfOpen,
 	}
 }
 
@@ -230,11 +232,14 @@ func (r *connRegistry) tryAddHalfOpen(source string) bool {
 	return r.addHalfOpenLocked(source)
 }
 
-// addHalfOpenLocked increments the half-open count for source, or returns false if
-// the per-source cap is already reached. The caller must hold r.mu. It is the single
-// admission check shared by tryAddHalfOpen and reserveSource.
+// addHalfOpenLocked admits one half-open session, or returns false if the global
+// half-open ceiling (maxHalfOpen) is already reached. The caller must hold r.mu. It
+// is the single admission check shared by tryAddHalfOpen and reserveSource. The
+// per-source halfOpen map is kept for release idempotency (see releaseHalfOpen), not
+// for a per-source cap: reserveSource dedups per source before calling this, so a
+// source holds at most one half-open slot.
 func (r *connRegistry) addHalfOpenLocked(source string) bool {
-	if r.halfOpen[source] >= constants.DatagramMaxHalfOpenPerSource {
+	if r.halfOpenTotal >= r.maxHalfOpen {
 		return false
 	}
 	r.halfOpen[source]++
@@ -353,8 +358,8 @@ type DatagramEndpoint struct {
 	// anti-DoS gate (see dgram_cookie.go).
 	cookie *cookieSigner
 	// cookiePressureHighWater is the load at which the endpoint demands a cookie
-	// from new sources; defaulted from constants, lowered (in-package) for tests
-	// so pressure can be forced without thousands of real sources.
+	// from new sources; derived as maxHalfOpen/2 in newEndpoint, lowered (in-package)
+	// for tests so pressure can be forced without thousands of real sources.
 	cookiePressureHighWater int
 
 	// rtoInitial/rtoMax bound handshake retransmission backoff; defaulted from
@@ -377,6 +382,11 @@ type DatagramEndpoint struct {
 	// set by WithReceiveSockets; 0 means use the default. Ignored by
 	// NewDatagramEndpoint.
 	receiveSockets int
+
+	// maxHalfOpen is the operator override for the half-open ceiling, set by
+	// WithMaxHalfOpen; 0 means autoscale with core count. newEndpoint resolves it into
+	// the registry's hard cap and the cookie-pressure water-mark.
+	maxHalfOpen int
 
 	closeOnce sync.Once
 	done      chan struct{}
@@ -404,6 +414,31 @@ func WithReceiveSockets(n int) DatagramEndpointOption {
 	return func(e *DatagramEndpoint) { e.receiveSockets = n }
 }
 
+// WithMaxHalfOpen overrides the concurrent half-open handshake ceiling (the number
+// of in-progress, not-yet-established responder sessions the endpoint admits before
+// dropping new sources). The default autoscales with core count
+// (clamp(GOMAXPROCS*DatagramMaxHalfOpenPerCore, floor, ceiling)); set this to pin a
+// fixed budget for a known deployment. Values below 1 are ignored (autoscale stays
+// in effect); larger values are honored as-is. The cookie-pressure water-mark tracks
+// at half the effective ceiling.
+func WithMaxHalfOpen(n int) DatagramEndpointOption {
+	return func(e *DatagramEndpoint) { e.maxHalfOpen = n }
+}
+
+// clampMaxHalfOpen returns the autoscaled half-open ceiling for a host with the given
+// core count: cores * per-core allotment, clamped to [floor, ceiling]. Pure so the
+// scaling curve is testable without touching GOMAXPROCS.
+func clampMaxHalfOpen(cores int) int {
+	n := cores * constants.DatagramMaxHalfOpenPerCore
+	if n < constants.DatagramMaxHalfOpenFloor {
+		return constants.DatagramMaxHalfOpenFloor
+	}
+	if n > constants.DatagramMaxHalfOpenCeiling {
+		return constants.DatagramMaxHalfOpenCeiling
+	}
+	return n
+}
+
 // NewDatagramEndpoint wraps a PacketConn (a *net.UDPConn in production, or a
 // fault-injecting conn in tests). It does not start the receive loop; callers
 // start it explicitly so tests can drive routing deterministically. It returns an
@@ -423,21 +458,29 @@ func newEndpoint(conn net.PacketConn, opts []DatagramEndpointOption) (*DatagramE
 		return nil, err
 	}
 	e := &DatagramEndpoint{
-		conn:                    conn,
-		batch:                   newBatchIO(conn),
-		registry:                newConnRegistry(),
-		reasm:                   NewReassembler(0, 0, 0),
-		acceptCh:                make(chan *datagramSession, 16),
-		cookie:                  cookie,
-		cookiePressureHighWater: constants.DatagramCookiePressureHighWater,
-		rtoInitial:              time.Duration(constants.DatagramHandshakeInitialTimeoutMillis) * time.Millisecond,
-		rtoMax:                  time.Duration(constants.DatagramHandshakeMaxTimeoutMillis) * time.Millisecond,
-		idleTimeout:             time.Duration(constants.DatagramIdleTimeoutSeconds) * time.Second,
-		done:                    make(chan struct{}),
+		conn:        conn,
+		batch:       newBatchIO(conn),
+		reasm:       NewReassembler(0, 0, 0),
+		acceptCh:    make(chan *datagramSession, 16),
+		cookie:      cookie,
+		rtoInitial:  time.Duration(constants.DatagramHandshakeInitialTimeoutMillis) * time.Millisecond,
+		rtoMax:      time.Duration(constants.DatagramHandshakeMaxTimeoutMillis) * time.Millisecond,
+		idleTimeout: time.Duration(constants.DatagramIdleTimeoutSeconds) * time.Second,
+		done:        make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(e)
 	}
+	// Resolve the half-open ceiling after opts: autoscale with core count unless an
+	// operator pinned it via WithMaxHalfOpen. The cookie-pressure water-mark and the
+	// reassembler's source cap both track it so the soft (cookie) and hard (drop)
+	// anti-DoS signals stay proportional across host sizes.
+	if e.maxHalfOpen < 1 {
+		e.maxHalfOpen = clampMaxHalfOpen(runtime.GOMAXPROCS(0))
+	}
+	e.cookiePressureHighWater = e.maxHalfOpen / 2
+	e.registry = newConnRegistry(e.maxHalfOpen)
+	e.reasm.maxSources = e.maxHalfOpen
 	return e, nil
 }
 

--- a/pkg/tunnel/datagram_test.go
+++ b/pkg/tunnel/datagram_test.go
@@ -20,7 +20,7 @@ func mustEndpoint(t *testing.T, conn net.PacketConn) *DatagramEndpoint {
 }
 
 func TestConnRegistryAddAssignsUniqueNonZeroIndices(t *testing.T) {
-	r := newConnRegistry()
+	r := newConnRegistry(constants.DatagramMaxHalfOpenFloor)
 	const n = 1000
 	seen := make(map[uint32]*datagramSession, n)
 
@@ -47,7 +47,7 @@ func TestConnRegistryAddAssignsUniqueNonZeroIndices(t *testing.T) {
 }
 
 func TestConnRegistryLookupAndRemove(t *testing.T) {
-	r := newConnRegistry()
+	r := newConnRegistry(constants.DatagramMaxHalfOpenFloor)
 	ds := &datagramSession{}
 	idx, err := r.add(ds)
 	if err != nil {
@@ -72,21 +72,23 @@ func TestConnRegistryLookupAndRemove(t *testing.T) {
 }
 
 func TestConnRegistryHalfOpenCap(t *testing.T) {
-	r := newConnRegistry()
+	const ceiling = 4
+	r := newConnRegistry(ceiling)
 	const src = "203.0.113.7:51820"
 
-	for i := 0; i < constants.DatagramMaxHalfOpenPerSource; i++ {
+	// The ceiling is global, not per-source. tryAddHalfOpen is the direct primitive
+	// (reserveSource dedups in production), so it bumps the global counter each call.
+	for i := 0; i < ceiling; i++ {
 		if !r.tryAddHalfOpen(src) {
-			t.Fatalf("half-open %d should be admitted (cap %d)", i, constants.DatagramMaxHalfOpenPerSource)
+			t.Fatalf("half-open %d should be admitted (ceiling %d)", i, ceiling)
 		}
 	}
 	if r.tryAddHalfOpen(src) {
-		t.Fatal("half-open over the cap must be rejected")
+		t.Fatal("half-open over the global ceiling must be rejected")
 	}
-
-	// A different source is unaffected by the first source's cap.
-	if !r.tryAddHalfOpen("198.51.100.9:51820") {
-		t.Fatal("a distinct source must have its own half-open budget")
+	// A different source does NOT get its own budget: the ceiling is global.
+	if r.tryAddHalfOpen("198.51.100.9:51820") {
+		t.Fatal("the half-open ceiling is global; a distinct source must not bypass it")
 	}
 
 	// Releasing one slot lets exactly one more in.
@@ -95,7 +97,7 @@ func TestConnRegistryHalfOpenCap(t *testing.T) {
 		t.Fatal("after release, one more half-open should be admitted")
 	}
 	if r.tryAddHalfOpen(src) {
-		t.Fatal("still over the cap after a single release")
+		t.Fatal("still at the ceiling after a single release")
 	}
 }
 
@@ -134,12 +136,13 @@ func TestRouteDatagram(t *testing.T) {
 }
 
 func TestConnRegistryReleaseHalfOpenNeverNegative(t *testing.T) {
-	r := newConnRegistry()
+	const ceiling = 4
+	r := newConnRegistry(ceiling)
 	const src = "192.0.2.1:1"
-	// Release with no prior add must not underflow or panic, and the source must
-	// then accept the full cap.
+	// Release with no prior add must not underflow halfOpenTotal (the per-source map
+	// no-ops at 0), and the registry must then still accept the full ceiling.
 	r.releaseHalfOpen(src)
-	for i := 0; i < constants.DatagramMaxHalfOpenPerSource; i++ {
+	for i := 0; i < ceiling; i++ {
 		if !r.tryAddHalfOpen(src) {
 			t.Fatalf("admit %d after spurious release", i)
 		}

--- a/pkg/tunnel/dgram_cookie_gate_test.go
+++ b/pkg/tunnel/dgram_cookie_gate_test.go
@@ -58,7 +58,7 @@ func clientHelloFrame(t *testing.T, senderIndex uint32, recvIndex uint32, fragLe
 }
 
 func TestKnownSource(t *testing.T) {
-	r := newConnRegistry()
+	r := newConnRegistry(constants.DatagramMaxHalfOpenFloor)
 	const src = "203.0.113.7:5000"
 
 	if r.knownSource(0, src) {
@@ -86,7 +86,7 @@ func TestKnownSource(t *testing.T) {
 }
 
 func TestHalfOpenGlobalAccounting(t *testing.T) {
-	r := newConnRegistry()
+	r := newConnRegistry(constants.DatagramMaxHalfOpenFloor)
 	if r.halfOpenLoad() != 0 {
 		t.Fatalf("initial load = %d, want 0", r.halfOpenLoad())
 	}
@@ -233,11 +233,14 @@ func TestRouteRetryDeliversCookie(t *testing.T) {
 	}
 }
 
-// Guard: the pressure default is the configured constant.
+// Guard: the cookie-pressure water-mark is derived as half the (autoscaled) half-open
+// ceiling, and that ceiling is at least the floor.
 func TestCookiePressureDefault(t *testing.T) {
 	e := mustEndpoint(t, &captureConn{})
-	if e.cookiePressureHighWater != constants.DatagramCookiePressureHighWater {
-		t.Fatalf("default high-water = %d, want %d",
-			e.cookiePressureHighWater, constants.DatagramCookiePressureHighWater)
+	if e.maxHalfOpen < constants.DatagramMaxHalfOpenFloor {
+		t.Fatalf("autoscaled ceiling = %d, want >= floor %d", e.maxHalfOpen, constants.DatagramMaxHalfOpenFloor)
+	}
+	if want := e.maxHalfOpen / 2; e.cookiePressureHighWater != want {
+		t.Fatalf("high-water = %d, want maxHalfOpen/2 = %d", e.cookiePressureHighWater, want)
 	}
 }

--- a/pkg/tunnel/dgram_reuseport_test.go
+++ b/pkg/tunnel/dgram_reuseport_test.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/sara-star-quant/quantum-go/internal/constants"
 )
 
 // TestReserveSourceBootstrapRace drives two concurrent bootstrap ClientHellos for
@@ -72,18 +70,13 @@ func (c *blackholeConn) SetWriteDeadline(time.Time) error { return nil }
 
 // TestReserveSourceOutcomes exercises reserveSource's three outcomes directly: admit
 // a new source, route a second ClientHello for an in-progress source to the existing
-// responder, and drop once the per-source half-open cap is reached. It also asserts
-// the build closure runs ONLY on the admit path, so a lost retransmit or a capped
-// ClientHello allocates no session. This is the production bootstrap admission path
-// the SO_REUSEPORT fan-out relies on; the tryAddHalfOpen-based tests no longer cover
-// it since reserveSource owns the decision.
-//
-// The cap branch is defensive: in production reserveSource is the only half-open
-// incrementer and it dedups per source (the existing-responder check fires first), so
-// one source tops out at a single in-progress responder and never reaches the cap on
-// its own. The test fills the slots directly via tryAddHalfOpen to reach that branch.
+// responder, and drop a new source once the global half-open ceiling is reached. It
+// also asserts the build closure runs ONLY on the admit path, so a lost retransmit or
+// a capped ClientHello allocates no session. This is the production bootstrap
+// admission path the SO_REUSEPORT fan-out relies on.
 func TestReserveSourceOutcomes(t *testing.T) {
-	r := newConnRegistry()
+	const ceiling = 2
+	r := newConnRegistry(ceiling)
 	builds := 0
 	build := func() *datagramSession { builds++; return &datagramSession{} }
 
@@ -106,20 +99,57 @@ func TestReserveSourceOutcomes(t *testing.T) {
 		t.Fatalf("after retransmit: builds=%d halfOpen=%d, want unchanged 1 and 1", builds, r.halfOpenLoad())
 	}
 
-	// Capped source: fill its half-open slots, then reserveSource must drop without building.
-	const capped = "198.51.100.4:51820"
-	for i := 0; i < constants.DatagramMaxHalfOpenPerSource; i++ {
-		if !r.tryAddHalfOpen(capped) {
-			t.Fatalf("slot %d for capped source should be admitted (cap %d)", i, constants.DatagramMaxHalfOpenPerSource)
-		}
+	// Fill the last slot so the global ceiling is reached, then a brand-new source
+	// must drop without building. The existing-source check is first, so this proves
+	// the global-cap branch, not the dedup branch.
+	if !r.tryAddHalfOpen("198.51.100.4:51820") {
+		t.Fatal("second slot should be admitted below the ceiling")
 	}
 	buildsBefore := builds
-	ds, won := r.reserveSource(capped, build)
+	ds, won := r.reserveSource("198.51.100.9:51820", build)
 	if won || ds != nil {
-		t.Fatalf("capped source: got (%v, %v), want (nil, false)", ds, won)
+		t.Fatalf("at ceiling: got (%v, %v), want (nil, false)", ds, won)
 	}
 	if builds != buildsBefore {
 		t.Fatalf("build ran on the capped path (%d -> %d), want no allocation", buildsBefore, builds)
+	}
+}
+
+// TestClampMaxHalfOpen pins the autoscale curve: cores * per-core, clamped to the
+// floor and ceiling. The values track perCore=256, floor=1024, ceiling=8192.
+func TestClampMaxHalfOpen(t *testing.T) {
+	cases := []struct{ cores, want int }{
+		{1, 1024}, {4, 1024}, {8, 2048}, {16, 4096}, {32, 8192}, {64, 8192},
+	}
+	for _, c := range cases {
+		if got := clampMaxHalfOpen(c.cores); got != c.want {
+			t.Errorf("clampMaxHalfOpen(%d) = %d, want %d", c.cores, got, c.want)
+		}
+	}
+}
+
+// TestWithMaxHalfOpen checks the operator override flows through to the registry's
+// hard cap, the reassembler's source cap, and the cookie-pressure water-mark (half
+// the ceiling), bypassing autoscale.
+func TestWithMaxHalfOpen(t *testing.T) {
+	const n = 256
+	e, err := NewDatagramEndpoint(newBlackholeConn(), WithMaxHalfOpen(n))
+	if err != nil {
+		t.Fatalf("NewDatagramEndpoint: %v", err)
+	}
+	defer func() { _ = e.Close() }()
+
+	if e.maxHalfOpen != n {
+		t.Fatalf("endpoint maxHalfOpen = %d, want %d", e.maxHalfOpen, n)
+	}
+	if e.registry.maxHalfOpen != n {
+		t.Fatalf("registry maxHalfOpen = %d, want %d", e.registry.maxHalfOpen, n)
+	}
+	if e.reasm.maxSources != n {
+		t.Fatalf("reassembler maxSources = %d, want %d", e.reasm.maxSources, n)
+	}
+	if e.cookiePressureHighWater != n/2 {
+		t.Fatalf("cookie water-mark = %d, want %d", e.cookiePressureHighWater, n/2)
 	}
 }
 

--- a/pkg/tunnel/reassembly.go
+++ b/pkg/tunnel/reassembly.go
@@ -66,7 +66,7 @@ func NewReassembler(maxConcurrentPerSource, maxMessageSize int, timeout time.Dur
 	}
 	return &Reassembler{
 		bySource:               make(map[string]map[reasmKey]*fragmentBuffer),
-		maxSources:             constants.DatagramMaxHalfOpenTotal,
+		maxSources:             constants.DatagramMaxHalfOpenFloor,
 		maxConcurrentPerSource: maxConcurrentPerSource,
 		maxMessageSize:         maxMessageSize,
 		timeout:                timeout,


### PR DESCRIPTION
## What

Make the datagram half-open ceiling a real, enforced, core-scaled bound, and repurpose the dead per-source cap into it.

- **Enforce the global ceiling.** `reserveSource` never dropped a new source at the global half-open count: the 1024 total only fed the cookie-pressure water-mark and the reassembler source cap. A source past the cookie gate could pin unbounded half-open responder sessions (a goroutine + CH-KEM state each). `addHalfOpenLocked` now drops when `halfOpenTotal` reaches the ceiling; `reserveSource` checks the existing-source case first, so in-progress sources stay exempt (retransmits still route) and only new sources hit the ceiling.
- **Autoscale + override.** Default ceiling is `clamp(GOMAXPROCS * 256, 1024, 8192)` so a busy multi-core server gets proportional headroom while a small host stays bounded. `WithMaxHalfOpen(n)` pins a fixed budget. The cookie water-mark (`ceiling/2`) and the reassembler source cap track the ceiling so the soft (cookie) and hard (drop) anti-DoS signals stay proportional.
- **Repurpose the dead per-source cap.** It was unreachable (`reserveSource` dedups a source to one in-progress responder). The per-source `halfOpen` map stays, now solely for release idempotency (`releaseHalfOpen` no-ops at zero, so a stray double-release cannot underflow the counter); only the per-source threshold + constant go away. `DatagramMaxHalfOpenTotal`/`PerSource` become `Floor`/`PerCore`/`Ceiling` knobs.

## Docs

- `docs/datagram-dos.md`: the "half of the hard half-open cap" line over-promised a cap the registry never enforced; updated to the now-true enforced + autoscaled model.
- `docs/datagram-transport.md`: documents the `ListenDatagram` / `WithReceiveSockets` SO_REUSEPORT API (previously undocumented) and `WithMaxHalfOpen`, plus a high-assurance deployment example (pinned budget + handshake padding) framed as capacity/DoS knobs only, not a certified BSI/FIPS profile.

## Tests

- Global-cap drop via `reserveSource` (build closure does not run on the drop path).
- `clampMaxHalfOpen` autoscale curve {1,4,8,16,32,64} cores -> {1024,1024,2048,4096,8192,8192}.
- `WithMaxHalfOpen` override wiring (registry cap, reassembler maxSources, cookie water-mark).
- Reworked the per-source-cap tests to global-cap semantics; exercises the kept release-idempotency guard.

## Verification

- `go vet ./...` clean
- `go test -race ./...` green (all packages)
- `GOOS=linux GOARCH=amd64 go build ./...` builds the SO_REUSEPORT path

## Note

Stacked on #54 (build-closure refactor). `perCore=256` and `ceiling=8192` are tuning numbers that ideally want a memory-vs-load benchmark to finalize; the floor/ceiling clamp keeps the design safe for any reasonable value, and `floor=1024` is today's number.
