### PR TITLE
publish measured datagram throughput numbers and refresh perf docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Rebranded to "tunnel"**, the precise term for this project. The CLI binary is now `quantum-tunnel`, the Prometheus metric namespace `quantum_vpn` is now `quantum_tunnel`, and the CH-KEM protocol and key-derivation labels move to `CH-KEM-Tunnel-*`.
 
+### Performance
+- **Datagram data plane**: zero-alloc steady-state send (in-place AEAD into a reused buffer), batched `recvmmsg`/`sendmmsg` on Linux, `SO_REUSEPORT` multi-socket receive that spreads demux and AEAD-open across cores, and a coarse activity clock that drops per-datagram `time.Now()`. Measured on an 8-core arm64 Linux container (loopback, indicative): single-flow delivered goodput ~280 MB/s (~2.2 Gb/s); a single receive goroutine tops out ~365 MB/s aggregate, which `SO_REUSEPORT` lifts ~1.6x to ~565 MB/s across 8 sockets; isolated send ~1.2 GB/s; batched receive ~1030 MB/s. Reaching the ~2.5 GB/s aggregate mark needs more cores plus `UDP_SEGMENT`/`UDP_GRO` offload (roadmap).
+
 ### Not yet implemented (datagram)
-- Data-path performance work (zero-alloc steady state, batched syscalls) and a datagram throughput benchmark.
 - The stateless cookie/RETRY anti-amplification exchange and connection roaming.
 
 ### Planned: v0.0.11 - Security Hardening (carryover)

--- a/README.md
+++ b/README.md
@@ -120,16 +120,23 @@ absolutes; relative figures are sound):**
 
 | Metric | Result |
 |--------|--------|
-| Datagram goodput (UDP, one-way single flow, delivered) | ~230 MB/s (~1.8 Gb/s) |
+| Datagram goodput (UDP, one-way single flow, delivered) | ~280 MB/s (~2.2 Gb/s) |
+| Datagram aggregate goodput (single receive goroutine, 1-8 flows) | peaks ~365 MB/s near 4 flows, then plateaus |
+| Datagram aggregate goodput (`SO_REUSEPORT`, 8 flows, 1->8 sockets) | ~355 -> ~565 MB/s (~1.6x across 8 cores) |
 | Datagram send (isolated, zero-alloc steady state) | ~1.2 GB/s |
-| Datagram receive, `recvmmsg` batch vs one syscall per datagram | ~945 vs ~830 MB/s (~+14%) |
+| Datagram receive, `recvmmsg` batch vs one syscall per datagram | ~1030 vs ~975 MB/s |
 
 The end-to-end goodput is delivered throughput (the benchmark flow-controls the
 sender so dropped datagrams are never counted), the full path: seal, send, kernel,
-receive loop, demux, AEAD open, delivery. A CPU profile of that path is ~35% AES
-(already hardware-accelerated), ~30% syscalls, the rest framing/alloc/bookkeeping;
-work toward higher per-flow and multi-Gb aggregate throughput (GSO/GRO offload,
-pooled receive) is tracked on the [roadmap](docs/ROADMAP.md). Optional handshake
+receive loop, demux, AEAD open, delivery. A single receive goroutine demuxing and
+AEAD-opening every datagram is the per-endpoint ceiling (~365 MB/s aggregate on this
+8-core VM); `ListenDatagram` spreads that work across cores with `SO_REUSEPORT`,
+lifting aggregate goodput ~1.6x (to ~565 MB/s here) and scaling further on a
+many-core host. A CPU profile of the delivered path is ~35% AES (already
+hardware-accelerated), ~30% syscalls, the rest framing/alloc/bookkeeping. The
+~2.5 GB/s aggregate mark is a cores-in-parallel target (AES-GCM is ~2.5 GB/s/core):
+reaching it takes more cores than this VM plus fewer syscalls per datagram, which
+`UDP_SEGMENT`/`UDP_GRO` offload (on the [roadmap](docs/ROADMAP.md)) provides. Optional handshake
 padding (`WithHandshakePadding`) trades roughly +42% handshake bandwidth (a
 ClientHello flight grows from ~1700 to 2400 bytes) for uniform-size,
 fingerprint-resistant handshake datagrams; it never touches the data plane.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -353,9 +353,12 @@ items #2 (nonce session binding) and #5 (replay window expansion) natively for U
 
 ### Phase 1b - Performance
 
-- [ ] Zero-alloc steady-state data path (in-place AEAD into a reused buffer)
-- [ ] Batched syscalls (`recvmmsg`/`sendmmsg` via `golang.org/x/net` `ipv4`/`ipv6`)
-- [ ] Coarse deadlines / atomic activity timestamp (no per-packet `time.Now()`)
+- [x] Zero-alloc steady-state data path (in-place AEAD into a reused buffer)
+- [x] Batched syscalls (`recvmmsg`/`sendmmsg` via `golang.org/x/net` `ipv4`/`ipv6`)
+- [x] Coarse deadlines / atomic activity timestamp (no per-packet `time.Now()`)
+- [x] `SO_REUSEPORT` multi-socket receive (demux + AEAD-open spread across cores; ~1.6x aggregate on 8 cores)
+- [ ] `UDP_SEGMENT`/`UDP_GRO` offload (fewer syscalls per datagram, toward multi-Gb aggregate)
+- [ ] Parallel per-datagram crypto pipeline
 
 ### Phase 2 - DoS / amplification hardening
 

--- a/docs/datagram-transport.md
+++ b/docs/datagram-transport.md
@@ -149,6 +149,14 @@ per socket, so demux and AEAD-open spread across cores. On platforms without
 `SO_REUSEPORT` it transparently degrades to one socket. `NewDatagramEndpoint`
 (single socket) is unchanged.
 
+Measured on an 8-core arm64 Linux container (loopback, indicative): a single receive
+goroutine tops out around 365 MB/s aggregate delivered goodput; spreading receive
+across sockets lifts it about 1.6x, from ~355 MB/s (1 socket) to ~565 MB/s (8
+sockets). The scaling is sublinear here because the loopback path and the benchmark's
+own senders share the same 8 cores; a many-core host with real NIC receive queues has
+more headroom. The single-flow path remains syscall-bound (~280 MB/s, ~2.2 Gb/s), so
+the next per-flow lever is `UDP_SEGMENT`/`UDP_GRO` offload (see "Out of scope" below).
+
 ```go
 ep, err := tunnel.ListenDatagram("udp", "0.0.0.0:51820")
 if err != nil { /* ... */ }

--- a/docs/usage/CLI.md
+++ b/docs/usage/CLI.md
@@ -94,7 +94,8 @@ quantum-tunnel bench --handshakes 100 --throughput --size 500MB
 - **Handshakes (datagram/UDP)**: ~1,300/sec (~760us each, full CH-KEM, sequential)
 - **Cipher throughput**: ~2.5 GB/s AES-256-GCM raw AEAD (ARMv8 Crypto Extensions); ~0.7 GB/s ChaCha20-Poly1305
 - **Single-tunnel throughput (stream/TCP)**: ~690 MB/s (5.5 Gb/s) end-to-end over TCP, sustained across automatic rekeys
-- **Datagram data path (UDP)**: encrypted, zero-alloc send (~3 GB/s isolated on M1 Pro darwin); one-way single-flow delivered goodput ~58 MB/s on macOS loopback (a loopback artifact) and ~1.8 Gb/s on Linux (container arm64, indicative)
+- **Datagram data path (UDP)**: encrypted, zero-alloc send (~3 GB/s isolated on M1 Pro darwin); one-way single-flow delivered goodput ~58 MB/s on macOS loopback (a loopback artifact) and ~280 MB/s (~2.2 Gb/s) on Linux (container arm64, indicative)
+- **Datagram aggregate (UDP, Linux `SO_REUSEPORT`)**: a single receive goroutine tops out ~365 MB/s aggregate; spreading receive across 8 sockets lifts it ~1.6x to ~565 MB/s on an 8-core container, scaling further on a many-core host
 
 > The datagram data path is syscall-bound, not crypto-bound; macOS loopback has a slow
 > per-datagram socket path, so its single-flow number is a loopback artifact rather than a


### PR DESCRIPTION
## What

Publish the datagram aggregate/scaling throughput numbers (which lived nowhere in the docs) and refresh the stale single-flow and roadmap wording. Docs only, no production code change.

## Numbers

Rig: 8-core arm64 Linux container (Docker, kernel 6.12, loopback), `go test -bench -count=10` summarized with benchstat. Loopback/VM, labeled indicative per the existing convention.

- Single-flow delivered goodput: ~280 MB/s (~2.2 Gb/s), up from the documented ~230 (the receive alloc cut helped).
- Single-socket aggregate (one receive goroutine, 1-8 flows): peaks ~365 MB/s near 4 flows, then plateaus.
- `SO_REUSEPORT` scaling (8 flows, 1->8 sockets): ~355 -> ~565 MB/s, ~1.6x across 8 cores.
- recvmmsg batch vs single: ~1030 vs ~975 MB/s.
- Isolated send: ~1.2 GB/s.

## Why

The `SO_REUSEPORT` multi-socket receive scaling landed earlier but never got an aggregate number in the docs; the README still called it and pooled receive "on the roadmap." 2.5 GB/s aggregate is a cores-in-parallel target, so this 8-core VM shows the scaling curve, not the ceiling. The remaining per-flow lever, `UDP_SEGMENT` / `UDP_GRO` offload, stays on the roadmap.

## Files

README.md, CHANGELOG.md, docs/usage/CLI.md, docs/datagram-transport.md, docs/ROADMAP.md.
