### PR TITLE
reuse the stream receive buffer instead of allocating per record

### DIFF
--- a/pkg/protocol/codec.go
+++ b/pkg/protocol/codec.go
@@ -455,6 +455,39 @@ func (c *Codec) ReadMessage(r io.Reader) ([]byte, error) {
 	return msg, nil
 }
 
+// ReadMessageInto reads a complete message into buf, reusing it when it is large
+// enough and reallocating (returning the new backing slice) otherwise. The returned
+// slice aliases buf, so the caller MUST be done with it before the next
+// ReadMessageInto call on the same buffer. It is the allocation-free hot-path twin of
+// ReadMessage for a single-reader loop; ReadMessage stays for the handshake and any
+// caller that needs an independent slice.
+func (c *Codec) ReadMessageInto(r io.Reader, buf []byte) ([]byte, error) {
+	var header [HeaderSize]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+
+	payloadLen := binary.BigEndian.Uint32(header[1:5])
+	if payloadLen > MaxMessageSize {
+		return nil, qerrors.ErrMessageTooLarge
+	}
+
+	total := HeaderSize + int(payloadLen)
+	if cap(buf) < total {
+		buf = make([]byte, total)
+	}
+	buf = buf[:total]
+	copy(buf, header[:])
+
+	if payloadLen > 0 {
+		if _, err := io.ReadFull(r, buf[HeaderSize:]); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf, nil
+}
+
 // GetMessageType returns the type of a serialized message.
 func (c *Codec) GetMessageType(data []byte) (MessageType, error) {
 	if len(data) < 1 {

--- a/pkg/tunnel/transport.go
+++ b/pkg/tunnel/transport.go
@@ -28,6 +28,13 @@ type Transport struct {
 	conn    net.Conn
 	codec   *protocol.Codec
 
+	// readBuf is the reused per-record receive buffer. Receive is single-reader and a
+	// record is consumed within one Receive iteration (DecodeData copies the
+	// ciphertext out, Decrypt returns a fresh plaintext), so the buffer is reused
+	// across records instead of allocated per record. Owned by the lone receive
+	// goroutine.
+	readBuf []byte
+
 	// Timeouts
 	readTimeout  time.Duration
 	writeTimeout time.Duration
@@ -217,8 +224,7 @@ func (t *Transport) readMessage() ([]byte, protocol.MessageType, error) {
 	if t.readTimeout > 0 {
 		_ = t.conn.SetReadDeadline(time.Now().Add(t.readTimeout))
 	}
-
-	msg, err := t.codec.ReadMessage(t.conn)
+	msg, err := t.codec.ReadMessageInto(t.conn, t.readBuf)
 	if err != nil {
 		if err == io.EOF {
 			return nil, 0, qerrors.ErrTunnelClosed
@@ -226,6 +232,10 @@ func (t *Transport) readMessage() ([]byte, protocol.MessageType, error) {
 		t.recordProtocolError(err)
 		return nil, 0, err
 	}
+	// Retain the (possibly grown) backing buffer for the next record. msg is consumed
+	// within this Receive iteration - DecodeData copies the ciphertext out and Decrypt
+	// returns a fresh plaintext - so reusing it on the next read is safe.
+	t.readBuf = msg
 
 	msgType, err := t.codec.GetMessageType(msg)
 	if err != nil {

--- a/pkg/tunnel/transport_throughput_test.go
+++ b/pkg/tunnel/transport_throughput_test.go
@@ -1,0 +1,116 @@
+package tunnel
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	"github.com/sara-star-quant/quantum-go/pkg/crypto"
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// benchStreamPair returns an established sender/receiver Transport pair over a real
+// TCP loopback connection. A real socket (not net.Pipe, which is a synchronous
+// in-memory hand-off) exercises the receive path's real syscalls and per-record
+// allocations. Keys are shared directly rather than via a full handshake.
+func benchStreamPair(b *testing.B) (sender, receiver *Transport, cleanup func()) {
+	b.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("listen: %v", err)
+	}
+	type accepted struct {
+		c   net.Conn
+		err error
+	}
+	accCh := make(chan accepted, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		accCh <- accepted{c, aerr}
+	}()
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		b.Fatalf("dial: %v", err)
+	}
+	acc := <-accCh
+	if acc.err != nil {
+		b.Fatalf("accept: %v", acc.err)
+	}
+
+	masterSecret := make([]byte, constants.CHKEMSharedSecretSize)
+	_ = crypto.SecureRandom(masterSecret)
+	cs, _ := NewSession(RoleInitiator)
+	_ = cs.InitializeKeys(masterSecret, constants.CipherSuiteAES256GCM)
+	ss, _ := NewSession(RoleResponder)
+	_ = ss.InitializeKeys(masterSecret, constants.CipherSuiteAES256GCM)
+
+	sender = &Transport{
+		session:      cs,
+		conn:         clientConn,
+		codec:        protocol.NewCodec(),
+		writeTimeout: 30 * time.Second,
+	}
+	receiver = &Transport{
+		session:     ss,
+		conn:        acc.c,
+		codec:       protocol.NewCodec(),
+		readTimeout: 30 * time.Second,
+	}
+	cleanup = func() {
+		_ = clientConn.Close()
+		_ = acc.c.Close()
+		_ = ln.Close()
+	}
+	return sender, receiver, cleanup
+}
+
+// BenchmarkStreamReceiveSmallRecords measures the small-record receive path: a sender
+// floods records continuously while the receiver drains b.N of them. It reports
+// per-record throughput and allocations - the receive loop reuses one buffer across
+// records, so allocations stay flat as the record rate climbs.
+func BenchmarkStreamReceiveSmallRecords(b *testing.B) {
+	for _, size := range []int{64, 256, 1024} {
+		b.Run(fmt.Sprintf("record=%dB", size), func(b *testing.B) {
+			sender, receiver, cleanup := benchStreamPair(b)
+			defer cleanup()
+			payload := make([]byte, size)
+
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					// Post-stop write errors (from the unblock deadline below) are
+					// expected; just exit. A real early failure surfaces as a receiver
+					// timeout, failing the benchmark there.
+					if err := sender.Send(payload); err != nil {
+						return
+					}
+				}
+			}()
+
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := receiver.Receive(); err != nil {
+					b.Fatalf("receive %d/%d: %v", i, b.N, err)
+				}
+			}
+			b.StopTimer()
+
+			close(stop)
+			_ = sender.conn.SetWriteDeadline(time.Now()) // unblock a sender parked in Write
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
## What

`Transport.Receive` allocated a fresh message buffer for every record through `codec.ReadMessage`. This adds `codec.ReadMessageInto`, which reads into a caller-owned buffer (reused when large enough, grown and returned otherwise), and lets the single-reader receive loop reuse one buffer across records.

`ReadMessage` stays as is - the handshake path (4 call sites) needs an independent slice and keeps using it.

## Safety

The receive loop fully consumes each record within its `Receive` iteration: `DecodeData` copies the ciphertext out of the buffer, and `Decrypt` returns a fresh plaintext from `cipher.Open(nil, ...)`. Nothing retains the buffer past the iteration, so reusing it on the next read is safe. Verified across all message handlers (Data, Rekey, Alert, Ping, Pong, Close) and with `-race`.

## Numbers

New `BenchmarkStreamReceiveSmallRecords` (Apple M1 Pro, TCP loopback, `count=8`, benchstat):

- B/op: -26% (e.g. 1224 -> 904 at 256-byte records)
- allocs/op: 8 -> 7 (-12.5%)
- sec/op: neutral (no significant change)

Fewer allocations cut GC pressure on a high-record-rate receiver.

## Dropped: buffered reader

I prototyped a `bufio.Reader` over the conn to also collapse the two reads per record (header + payload) into one buffered read. On the latency-bound loopback benchmark it added a copy and measured ~2.5% slower with no demonstrable backlog win, so I dropped it. The path is bound by per-record send + goroutine wakeup, not receive syscalls, on this rig. The reliable change is the buffer reuse; revisit a buffered reader only if a syscall-bound, multi-connection profile justifies it.
