### PR TITLE
document library scope: connection continuity vs out-of-scope client concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,35 @@ Quantum-Go is a production-ready, quantum-resistant tunnel encryption library im
 - Per-IP rate limiting and DoS protection
 - Prometheus metrics and OpenTelemetry tracing
 
+## Scope
+
+Quantum-Go is a tunnel **encryption library**, not a VPN client. It encrypts and
+authenticates bytes over a `net.Conn` or UDP socket. It does not configure, capture, or
+route operating-system network traffic.
+
+**What the library gives you (connection continuity):**
+
+- **Authenticated roaming** - a datagram session can survive the peer's IP or port
+  changing (NAT rebind, Wi-Fi to cellular): it demuxes by a random connection index, not
+  source address, and rebinds only after an AEAD-authenticated packet.
+- **Reliable handshake** - the post-quantum handshake retransmits lost flights with
+  backoff over a lossy UDP path.
+- **Rekey, resumption, and idle reaping** for long-lived sessions.
+
+**What the library does NOT do (the integrating application's responsibility):**
+
+- **Reconnect after a full disconnect** - the library has no auto-redial loop;
+  re-establishing with `Dial` / `DialDatagram` is the caller's responsibility.
+- **DNS leak prevention** - the library does not control the operating-system resolver.
+- **Kill-switch** - the library does not block non-tunnel traffic when the tunnel is down.
+- **TUN device and system routing** - the library does not capture or route host traffic
+  into the tunnel.
+
+These properties belong to a VPN client built around the library, not to the library
+itself. This text describes the software, not security or legal advice; Quantum-Go ships
+under the MIT License, "as is" and without warranty (see [LICENSE](LICENSE) and the
+Compliance & Liability section below).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Adds a **Scope** section to the README making the library/VPN-client boundary explicit, worded for legal clarity.

**Why:** the library encrypts and authenticates bytes over a `net.Conn`/UDP socket and stays below system network config. Readers evaluating it for a leak-proof VPN should know what it does and does not cover - without the README itself making guarantees or giving security advice.

**What the library gives you (connection continuity):** authenticated roaming (a session can survive NAT rebind / network switch via connection-index demux), reliable handshake retransmission, rekey / resumption / idle reaping.

**Outside scope (the client's responsibility):** reconnect after a full disconnect, DNS leak prevention, kill-switch, TUN device + system routing - each stated as a flat "the library does not do X", not as how-to instructions.

**Legal-clarity wording:** no guarantee words (dropped "leak-proof" and "secures"); each out-of-scope item is a boundary, not advice; an explicit note that the text describes the software, not security or legal advice, under the MIT as-is / no-warranty terms.

Docs-only, no code change.
