### PR TITLE
add a handshake timeout on the stream Accept path

### DIFF
--- a/pkg/tunnel/transport.go
+++ b/pkg/tunnel/transport.go
@@ -51,7 +51,11 @@ type Transport struct {
 type TransportConfig struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
-	RateLimit    RateLimitConfig
+	// HandshakeTimeout bounds how long the responder waits for a peer to complete the
+	// handshake on Accept. Without it a stalled peer pins a goroutine and session
+	// indefinitely (slow-loris). 0 means no handshake deadline.
+	HandshakeTimeout time.Duration
+	RateLimit        RateLimitConfig
 	// Observer is a shared observer for all sessions (ignored if ObserverFactory is set).
 	Observer Observer
 
@@ -80,8 +84,9 @@ type RateLimitConfig struct {
 // DefaultTransportConfig returns sensible defaults.
 func DefaultTransportConfig() TransportConfig {
 	return TransportConfig{
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		ReadTimeout:      30 * time.Second,
+		WriteTimeout:     30 * time.Second,
+		HandshakeTimeout: 30 * time.Second,
 	}
 }
 
@@ -738,10 +743,18 @@ func (l *Listener) performHandshake(session *Session, conn net.Conn, remoteIP st
 		return err
 	}
 
+	// Bound the handshake so a stalled peer cannot pin a goroutine + session forever.
+	// Cleared on success so the established transport's own per-op deadlines take over.
+	if l.config.HandshakeTimeout > 0 {
+		_ = conn.SetDeadline(time.Now().Add(l.config.HandshakeTimeout))
+	}
 	if err := ResponderHandshake(session, conn); err != nil {
 		l.failSession(session, err)
 		_ = conn.Close()
 		return err
+	}
+	if l.config.HandshakeTimeout > 0 {
+		_ = conn.SetDeadline(time.Time{})
 	}
 	return nil
 }

--- a/pkg/tunnel/transport_test.go
+++ b/pkg/tunnel/transport_test.go
@@ -12,6 +12,41 @@ import (
 	"github.com/sara-star-quant/quantum-go/pkg/protocol"
 )
 
+// TestResponderHandshakeTimeout verifies the Accept path tears down a peer that
+// connects and then stalls mid-handshake (slow-loris), rather than pinning the
+// goroutine and session forever. Without HandshakeTimeout the Accept goroutine would
+// block on the read indefinitely and the outer 2s guard would fire.
+func TestResponderHandshakeTimeout(t *testing.T) {
+	ln, err := Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	ln.config.HandshakeTimeout = 150 * time.Millisecond
+
+	// Connect, then send nothing: the responder waits for a ClientHello that never comes.
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = raw.Close() }()
+
+	done := make(chan error, 1)
+	go func() {
+		_, e := ln.Accept()
+		done <- e
+	}()
+
+	select {
+	case e := <-done:
+		if e == nil {
+			t.Fatal("Accept should fail when the peer stalls the handshake")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Accept hung past the handshake timeout")
+	}
+}
+
 func TestTransportAlerts(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	defer func() { _ = clientConn.Close() }()


### PR DESCRIPTION
## What

`Listener.performHandshake` called `ResponderHandshake` with no deadline, so a peer that connected and then stalled mid-handshake pinned a goroutine + session indefinitely (slow-loris). The handshake-rate limiter throttles *new* attempts but does nothing for an in-flight stall. The datagram transport already times out; the stream path did not.

## Change

- Add `HandshakeTimeout` to `TransportConfig`, default 30s (the CH-KEM handshake is sub-millisecond, so the bound only catches the abusive case; operators in hostile environments can lower it).
- `performHandshake` sets the connection deadline before `ResponderHandshake` and clears it on success, so the established transport's own per-op deadlines take over.
- Responder/`Accept` path only - a hung `Dial` is the client's own problem. Deadline only, no wire change.

## Verification

- New `TestResponderHandshakeTimeout`: a peer that connects and sends nothing gets torn down within the timeout instead of hanging.
- Existing end-to-end Listen/Dial round-trips (now with the 30s default active) pass under `-race`; full suite green.
