### PR TITLE
make the module-integrity self-test honest

### DIFF
--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -232,6 +232,12 @@ integrity := crypto.CheckModuleIntegrity()
 fmt.Printf("Verified: %v\n", integrity.Verified)
 ```
 
+This is a narrow check: it confirms the embedded known-answer-test (KAT) vectors have not
+been altered in the binary (SHA-256 against a value pinned at source). It does NOT hash the
+binary `.text` section, so it is not full FIPS 140-3 module integrity. A real binary/`.text`
+HMAC that fails hard in FIPS mode is future work; `Verified` reflects only the KAT-vector
+comparison.
+
 ## Conditional Self-Tests (CST)
 
 In addition to POST, FIPS 140-3 requires Conditional Self-Tests that run during specific cryptographic operations.

--- a/pkg/crypto/post.go
+++ b/pkg/crypto/post.go
@@ -227,14 +227,15 @@ func runMLKEMKAT() error {
 
 // ModuleIntegrity contains information about the crypto module's integrity
 type ModuleIntegrity struct {
-	// ExpectedHash is the expected SHA-256 hash of critical code sections
-	// In a real FIPS implementation, this would be computed at build time
+	// ExpectedHash is the SHA-256 of the embedded KAT vectors, pinned at source. It is
+	// NOT a hash of the binary .text section (see CheckModuleIntegrity).
 	ExpectedHash string
 
-	// ActualHash is computed at runtime
+	// ActualHash is the runtime SHA-256 of the same KAT vectors.
 	ActualHash string
 
-	// Verified indicates if the integrity check passed
+	// Verified is true when ActualHash matches ExpectedHash, i.e. the KAT vectors in the
+	// binary were not altered. It does NOT attest the binary as a whole.
 	Verified bool
 }
 
@@ -244,15 +245,13 @@ var (
 	postIntegrityOnce sync.Once
 )
 
-// CheckModuleIntegrity performs a module integrity check.
-// This is a simplified implementation - a full FIPS implementation would
-// hash the actual binary code sections.
-//
-// For this implementation, we verify that the KAT values themselves have not
-// been tampered with by checking their hash.
+// CheckModuleIntegrity verifies that the embedded known-answer-test (KAT) vectors have
+// not been altered in the binary, by comparing their SHA-256 against a value pinned at
+// source. This is a NARROW check: it covers the KAT vectors POST relies on, not the
+// binary .text section. Full module integrity (an HMAC over the .text/binary, failing
+// hard in FIPS mode) is future FIPS work; this no longer claims it.
 func CheckModuleIntegrity() *ModuleIntegrity {
 	postIntegrityOnce.Do(func() {
-		// Compute hash of KAT values
 		h := sha256.New()
 		h.Write(postKATKDFInput)
 		h.Write(postKATKDFExpected)
@@ -261,19 +260,16 @@ func CheckModuleIntegrity() *ModuleIntegrity {
 		h.Write(postKATAESPlaintext)
 		h.Write(postKATAESExpected)
 		h.Write(postKATMLKEMSeed)
-
 		actualHash := hex.EncodeToString(h.Sum(nil))
 
-		// Expected hash of the KAT values
-		// This was pre-computed and embedded at build time
-		expectedHash := "f3b5c7e8d9a1b2c4e5f6a7b8c9d0e1f2a3b4c5d6e7f8091a2b3c4d5e6f708192"
+		// SHA-256 of the KAT vectors above, pinned at source. A mismatch means a KAT
+		// vector was altered in the binary. Recompute and update this if the vectors change.
+		const expectedHash = "0aa6a0d630f79affdeb0850b02bf827416cb43bfd04a1bb1be7e2241c1ad1868"
 
 		postIntegrity = &ModuleIntegrity{
 			ExpectedHash: expectedHash,
 			ActualHash:   actualHash,
-			// In a real implementation, we would verify these match
-			// For now, we just record the actual hash
-			Verified: true, // Simplified - always passes
+			Verified:     actualHash == expectedHash,
 		}
 	})
 

--- a/pkg/crypto/post_test.go
+++ b/pkg/crypto/post_test.go
@@ -76,6 +76,13 @@ func TestCheckModuleIntegrity(t *testing.T) {
 		t.Error("ExpectedHash should not be empty")
 	}
 
+	// The KAT-vector hash must match the pinned value (a real comparison now, not a
+	// hardcoded pass). A failure here means the KAT vectors or the pinned hash drifted.
+	if !integrity.Verified || integrity.ActualHash != integrity.ExpectedHash {
+		t.Errorf("KAT-vector integrity should verify: actual=%s expected=%s verified=%v",
+			integrity.ActualHash, integrity.ExpectedHash, integrity.Verified)
+	}
+
 	t.Logf("Module integrity - Expected: %s, Actual: %s, Verified: %v",
 		integrity.ExpectedHash, integrity.ActualHash, integrity.Verified)
 }


### PR DESCRIPTION
## What

`crypto.CheckModuleIntegrity` returned `Verified: true` unconditionally (`// Simplified - always passes`) against a placeholder expected hash - it claimed a self-test it never performed. Nothing calls it in production, but `docs/FIPS.md:228` documents it as a FIPS feature, so the claim leaks into the FIPS story.

## Change

- Pin the real SHA-256 of the embedded KAT vectors (`0aa6a0d6...c1ad1868`) and set `Verified = (actualHash == expectedHash)` - the comparison now earns the `true` value.
- Scope it honestly in the struct doc, the function doc, and `docs/FIPS.md`: it confirms the KAT vectors were not altered in the binary, NOT the `.text` section. The notes flag a real binary/`.text` HMAC (failing hard in FIPS mode) as future work.
- `TestCheckModuleIntegrity` now asserts the comparison passes, so a future KAT-vector or pinned-hash drift fails loudly.

## Verification

- `go test ./pkg/crypto/...` and `go test -tags fips ./pkg/crypto/...` pass; full suite green. No production caller, so no live path changes behavior.
