### PR TITLE
prepare the v0.0.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+## [0.0.11][] - 2026-06-01
+
+**Theme:** Connectionless UDP/datagram transport (reliable handshake, encrypted data plane, reliable rekey, anti-DoS, Linux receive scaling and offload) and datagram performance, plus two stream-path hardening fixes.
+
 ### Added
 - **UDP/datagram transport (handshake)**: a connectionless transport alongside the TCP/stream one, demultiplexed by a random per-session connection index rather than source address (survives NAT rebind and roaming). It carries the full CH-KEM handshake over a lossy link: the large post-quantum Hellos are fragmented across datagrams and reassembled (`pkg/tunnel/reassembly.go`), and a transport-agnostic state machine plus reliability driver (`pkg/tunnel/dgram_handshake_{fsm,driver,wire}.go`) add retransmission with exponential backoff, a retry ceiling, duplicate/replay handling, and a responder linger that recovers a lost final flight. A bad or forged datagram drops rather than failing the handshake. The responder runs no decapsulation and sends no ServerHello until a full ClientHello arrives and a per-source half-open slot is granted, so it never sends more than it received from an unvalidated source. `DialDatagram` performs the initiator handshake and returns an established session.
 - **Datagram handshake benchmark**: `quantum-tunnel bench --datagram-handshakes N` measures the datagram handshake rate over loopback UDP (~1,300/sec, ~760 µs each on an M1 Pro, vs ~1,450/sec for the stream path).
@@ -20,13 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Datagram data plane**: zero-alloc steady-state send (in-place AEAD into a reused buffer), batched `recvmmsg`/`sendmmsg` on Linux, `SO_REUSEPORT` multi-socket receive that spreads demux and AEAD-open across cores, and a coarse activity clock that drops per-datagram `time.Now()`. Measured on an 8-core arm64 Linux container (loopback, indicative): single-flow delivered goodput ~280 MB/s (~2.2 Gb/s); a single receive goroutine tops out ~365 MB/s aggregate, which `SO_REUSEPORT` lifts ~1.6x to ~565 MB/s across 8 sockets; isolated send ~1.2 GB/s; batched receive ~1030 MB/s. Reaching the ~2.5 GB/s aggregate mark needs more cores plus GSO/GRO offload (roadmap).
 - **Datagram receive offload (Linux)**: `WithDatagramOffload()` enables `UDP_GRO`, so the kernel coalesces a same-flow datagram burst into one buffer and the receive loop re-splits it, cutting receive syscalls on a busy flow. Off by default and Linux-only; a no-op on other platforms, non-UDP conns, or kernels without `UDP_GRO`. Send-side `UDP_SEGMENT` (GSO) is not yet wired.
 
-### Not yet implemented (datagram)
-- The stateless cookie/RETRY anti-amplification exchange and connection roaming.
+### Security
+- **Handshake timeout on the stream Accept path**: `Listener.performHandshake` set no deadline around `ResponderHandshake`, so a peer that connected and stalled mid-handshake pinned a goroutine and session indefinitely (slow-loris). `TransportConfig.HandshakeTimeout` (default 30s) now bounds it; the datagram path already had timeouts.
+- **Honest module-integrity self-test**: `crypto.CheckModuleIntegrity` no longer hardcodes `Verified: true`. It pins the SHA-256 of the embedded KAT vectors and reports a real comparison, scoped in the docs as KAT-vector integrity, not binary `.text` integrity (which stays future FIPS work).
 
-### Planned: v0.0.11 - Security Hardening (carryover)
-- Handshake timeout on server Accept
-- Module integrity verification (fix always-true check)
-- CI security improvements (FIPS testing, Gosec enforcement)
+### Deferred (stream-path hardening, a later release)
+- Role binding in the CH-KEM transcript (reflection-attack resistance; affects the shared crypto core).
+- Resumption ticket server binding (`SHA-256(server public key)` in the ticket plaintext).
+- Stream-path session-bound AEAD nonce prefix and 1024-bit replay window (the datagram path already has both).
+- Real binary/`.text` module integrity (the KAT-vector check landed; full module integrity is future FIPS work).
+- CI security: drop the Gosec `-no-fail`, add a FIPS build/test job.
 
 ## [0.0.10][] - 2026-05-30
 
@@ -298,7 +305,8 @@ Benchmark results (Apple Silicon M1 Pro, Go 1.26):
 - Basic tunnel API
 - Unit tests for crypto primitives
 
-[Unreleased]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.10...HEAD
+[Unreleased]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.11...HEAD
+[0.0.11]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.7...v0.0.8

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,24 +124,26 @@ Quantum-Go implements a **Cascaded Hybrid KEM (CH-KEM)** providing:
    - **You must implement** authentication externally (certificates, PSK, static key pinning)
    - Identity binding to CH-KEM public keys is the deployer's responsibility
 
-2. **No role binding in CH-KEM transcript** (planned: v0.0.10):
+2. **No role binding in CH-KEM transcript** (planned: a later stream-hardening release):
    - The transcript hash does not include the initiator/responder role or protocol version
    - Theoretically enables reflection attacks (initiator completes handshake with itself)
    - Mitigated in practice by the handshake state machine (separate initiator/responder flows)
    - Full fix requires adding role indicator to `TranscriptHash` components
 
-3. **AEAD nonce prefix is zero** (planned: v0.0.10):
+3. **AEAD nonce prefix is zero** (planned: a later stream-hardening release):
    - Nonce format is `[0000 || counter(8B)]` -- the upper 4 bytes are not session-bound
    - Two sessions with the same encryption key would produce identical nonce sequences
    - Risk is low in practice because traffic keys are derived from unique shared secrets
+   - The datagram transport already derives a session-bound nonce prefix; this gap is the stream path only
    - Full fix: use session ID bytes as nonce prefix
 
-4. **Replay window is 64 packets** (planned: v0.0.10):
+4. **Replay window is 64 packets** (planned: a later stream-hardening release):
    - At high throughput (~83,000 pps at 1 Gbps), this gives <1ms tolerance for reordering
    - Packets arriving more than 64 positions out of order are silently dropped
+   - The datagram transport already uses a 1024-bit multi-word window; this gap is the stream path only
    - Full fix: expand to 1024+ using multi-word bitmap
 
-5. **Resumption tickets not bound to server identity** (planned: v0.0.10):
+5. **Resumption tickets not bound to server identity** (planned: a later stream-hardening release):
    - Session tickets contain only master secret and cipher suite
    - A captured ticket could theoretically be replayed against a different server
    - Risk is low: requires the attacker to know the ticket encryption key

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,13 @@
 
 ---
 
-## Current Status: v0.0.10
+## Current Status: v0.0.11
+
+> **Direction.** Next is **stream security parity**: bring the TCP/stream path up to the
+> datagram path and clear the hardening backlog (role binding, ticket server binding,
+> 1024-bit stream replay window, session-bound stream nonce, real `.text` module integrity,
+> CI security). After that, **crypto-agility and endpoint authentication** toward v0.1.0
+> (HQC code-based KEM diversification for a CH-KEM v2 triple cascade; peer authentication).
 
 ### Completed Features
 - [x] CH-KEM hybrid key exchange (X25519 + ML-KEM-1024)
@@ -21,7 +27,8 @@
 - [x] Prometheus metrics and OpenTelemetry tracing
 - [x] FIPS 140-3 build mode with POST/CST self-tests
 - [x] Regulatory clarity (EU open source exemption, user deployment guidance)
-- [x] UDP/datagram transport handshake (fragmented PQ flights, retransmission, replay; encrypted data path in progress)
+- [x] UDP/datagram transport (fragmented PQ handshake, encrypted data plane, reliable rekey, stateless cookie/anti-amplification, authenticated roaming, SO_REUSEPORT receive scaling, UDP_GRO offload)
+- [x] Stream handshake timeout on Accept (slow-loris bound); honest KAT-vector module-integrity check
 
 ---
 
@@ -218,10 +225,11 @@ composition needs strengthening.
 > **Status:** v0.0.10 shipped as *Data-Plane Rekey Reliability & Throughput* (see
 > CHANGELOG): the rekey send-deadlock fix, dual-cipher trial-decryption activation
 > (item #6 below, delivered without a new wire message), the boundary-packet replay fix,
-> the 64 GiB rekey-byte threshold, and the stdlib `crypto/sha3` migration. The remaining
-> hardening items below (role binding, nonce session binding, ticket server binding,
-> handshake timeout, replay-window expansion, module integrity) carry forward to a
-> subsequent hardening release.
+> the 64 GiB rekey-byte threshold, and the stdlib `crypto/sha3` migration. v0.0.11 then
+> shipped the datagram transport plus two of these items - handshake timeout (#4) and an
+> honest KAT-vector module-integrity check (#7, full `.text` integrity still pending). The
+> rest (role binding, ticket server binding, and the stream-path nonce/replay catch-up)
+> carry forward to the stream-security-parity release.
 
 #### 1. Role Binding in CH-KEM Transcript
 **Priority:** Critical | **Effort:** Small
@@ -271,9 +279,9 @@ can be replayed against a different server that shares the same ticket encryptio
 `Listener.Accept()` calls `ResponderHandshake` with no timeout. A malicious client
 can connect and never send data, exhausting goroutines and file descriptors.
 
-- [ ] Set `conn.SetDeadline` before `ResponderHandshake`
-- [ ] Make handshake timeout configurable via `TransportConfig` (default: 30s)
-- [ ] Add test: verify slow-loris style connections are terminated
+- [x] Set `conn.SetDeadline` before `ResponderHandshake` (v0.0.11)
+- [x] Make handshake timeout configurable via `TransportConfig` (default: 30s) (v0.0.11)
+- [x] Add test: verify slow-loris style connections are terminated (v0.0.11)
 
 #### 5. Replay Window Expansion
 **Priority:** Medium | **Effort:** Small
@@ -306,12 +314,14 @@ decryption (try current, fall back to pending). Reliable under load and high lat
 #### 7. Module Integrity Verification
 **Priority:** Medium | **Effort:** Medium
 
-`CheckModuleIntegrity()` unconditionally returns `Verified: true` with a placeholder hash.
+`CheckModuleIntegrity()` used to unconditionally return `Verified: true` with a placeholder
+hash. v0.0.11 made it honest: a real comparison of the embedded KAT vectors against a pinned
+hash, scoped in the docs as KAT-vector integrity, not binary `.text` integrity.
 
-- [ ] Implement build-time hash embedding (HMAC of `.text` section or binary)
-- [ ] Compare actual vs expected hash at runtime
-- [ ] In FIPS mode: fail hard if integrity check fails
-- [ ] Alternative: remove `Verified: true` and document as not-yet-implemented
+- [x] Pin the real KAT-vector hash and report a real comparison; document the scope (v0.0.11)
+- [ ] Implement build-time `.text`/binary HMAC embedding (full module integrity)
+- [ ] Compare actual vs expected `.text` hash at runtime
+- [ ] In FIPS mode: fail hard if the `.text` integrity check fails
 
 #### 8. CI Security Improvements
 **Priority:** Medium | **Effort:** Low

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ const (
 	// Minor is the minor version (new features).
 	Minor = 0
 	// Patch is the patch version (bug fixes).
-	Patch = 10
+	Patch = 11
 	// Label is the optional pre-release label.
 	Label = ""
 )


### PR DESCRIPTION
## What

Finalizes v0.0.11: version bump, changelog, and the doc honesty fixes the v0.0.10 pivot left behind. This is the last PR before the `v0.0.11` tag.

## Changes

- **version.go** -> v0.0.11.
- **CHANGELOG.md**: `[Unreleased]` becomes `[0.0.11] - 2026-06-01` (datagram transport + perf + the two stream hardening fixes under a new Security section); fresh empty `[Unreleased]`; link refs fixed (the v0.0.10 links resolve now that the tag exists).
- **SECURITY.md**: the deferred hardening items said "planned: v0.0.10" but never shipped there; re-labeled to the stream-hardening release, with a note that the datagram path already covers the nonce and replay-window items.
- **CHANGELOG carryover**: replaced the incomplete list (it had dropped role binding and ticket binding) with the complete deferred set.
- **ROADMAP.md**: current status -> v0.0.11; direction recorded (stream security parity, then crypto-agility + endpoint auth); the handshake-timeout (#4) and module-integrity (#7) items checked off as shipped in v0.0.11.

## Verification

- `go build ./...` clean; `quantum-tunnel version` reads `v0.0.11`.
- Depends on the two hardening PRs (handshake timeout, module integrity) already merged; tag `v0.0.11` only after this merges.
