### PR TITLE
make gosec gate CI and add a FIPS build/test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,30 @@ jobs:
         with:
           args: --timeout=5m
 
+  fips:
+    name: FIPS Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+          cache: true
+
+      - name: go vet
+        run: |
+          go vet ./...
+          go vet -tags fips ./...
+
+      - name: FIPS build
+        run: go build -tags fips ./...
+
+      - name: FIPS tests (race)
+        run: go test -tags fips ./... -race
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -116,17 +140,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.22.11
+      # Run gosec under a pinned Go 1.26 toolchain rather than the securego/gosec
+      # Docker image, whose bundled Go is too old to load a `go 1.26` module
+      # (it errors on package load and exits non-zero, which -no-fail used to hide).
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          args: "-no-fail -fmt sarif -out gosec.sarif ./..."
+          go-version: "1.26.x"
+          cache: true
+
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11
+
+      - name: Run Gosec Security Scanner
+        run: gosec -fmt sarif -out gosec.sarif ./...
 
       - name: Upload SARIF file
+        if: always()
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: gosec.sarif
 
       - name: Upload Security Report
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: security-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Threat model**: the former `docs/compliance/RISK_ASSESSMENT.md` is reframed as `docs/technical/THREAT_MODEL.md`, an honest self-authored analysis (NIST SP 800-30 methodology), with the governance scaffolding that implied a team or audit process removed.
+- **CI security hardening**: gosec now fails CI on findings (dropped `-no-fail`); all current findings are triaged with justified `#nosec` annotations (bounded integer conversions, KAT nonce) and one replay cast rewritten to drop the conversion. Added a FIPS build/test job (`go test -tags fips -race ./...`) and a `go vet` step.
 
 ## [0.0.11][] - 2026-06-01
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -347,13 +347,13 @@ hash, scoped in the docs as KAT-vector integrity, not binary `.text` integrity.
 - [ ] Compare actual vs expected `.text` hash at runtime
 - [ ] In FIPS mode: fail hard if the `.text` integrity check fails
 
-#### 8. CI Security Improvements
+#### 8. CI Security Improvements (DONE)
 **Priority:** Medium | **Effort:** Low
 
-- [ ] Remove `-no-fail` from Gosec scanner configuration
-- [ ] Add FIPS build/test job: `go test -tags fips -race ./...`
-- [ ] Add `go vet -race` to CI matrix
-- [ ] Fix data race in benchmark tool (`atomic.AddInt64` for counters)
+- [x] Remove `-no-fail` from Gosec scanner configuration (all current findings triaged: 14 bounded G115 conversions + the KAT-nonce G407, each with a justified `#nosec`; one replay cast rewritten to drop the conversion)
+- [x] Add FIPS build/test job: `go test -tags fips -race ./...`
+- [x] Add `go vet` to CI (`go vet` has no `-race`; race stays on the test job)
+- [x] Benchmark tool data race: already resolved (`cmd/quantum-tunnel/bench.go` uses `atomic.Int64`)
 
 ---
 

--- a/pkg/crypto/post.go
+++ b/pkg/crypto/post.go
@@ -161,7 +161,7 @@ func runAESGCMKAT() error {
 	// Test encryption
 	// Note: Hardcoded nonce is intentional for KAT - we need deterministic values
 	// to verify the implementation produces expected outputs.
-	ciphertext := aesgcm.Seal(nil, postKATAESNonce, postKATAESPlaintext, nil) //nolint:gosec // G407: Hardcoded nonce is required for KAT
+	ciphertext := aesgcm.Seal(nil, postKATAESNonce, postKATAESPlaintext, nil) // #nosec G407 -- KAT requires a fixed, known nonce for deterministic output
 	if !bytes.Equal(ciphertext, postKATAESExpected) {
 		return fmt.Errorf("AES-GCM encrypt mismatch: got %x, want %x", ciphertext, postKATAESExpected)
 	}

--- a/pkg/protocol/codec.go
+++ b/pkg/protocol/codec.go
@@ -61,7 +61,7 @@ func (c *Codec) EncodeClientHello(m *ClientHello) ([]byte, error) {
 	// Header
 	buf[offset] = byte(MessageTypeClientHello)
 	offset++
-	binary.BigEndian.PutUint32(buf[offset:], uint32(payloadSize))
+	binary.BigEndian.PutUint32(buf[offset:], uint32(payloadSize)) // #nosec G115 -- payloadSize bounded by MaxMessageSize (65536), fits uint32
 	offset += 4
 
 	// Version
@@ -84,7 +84,7 @@ func (c *Codec) EncodeClientHello(m *ClientHello) ([]byte, error) {
 	offset += constants.CHKEMPublicKeySize
 
 	// Cipher suites
-	binary.BigEndian.PutUint16(buf[offset:], uint16(len(m.CipherSuites)))
+	binary.BigEndian.PutUint16(buf[offset:], uint16(len(m.CipherSuites))) // #nosec G115 -- cipher suite count is single digits, fits uint16
 	offset += 2
 	for _, cs := range m.CipherSuites {
 		binary.BigEndian.PutUint16(buf[offset:], uint16(cs))
@@ -175,7 +175,7 @@ func (c *Codec) EncodeServerHello(m *ServerHello) ([]byte, error) {
 	// Header
 	buf[offset] = byte(MessageTypeServerHello)
 	offset++
-	binary.BigEndian.PutUint32(buf[offset:], uint32(payloadSize))
+	binary.BigEndian.PutUint32(buf[offset:], uint32(payloadSize)) // #nosec G115 -- payloadSize bounded by MaxMessageSize (65536), fits uint32
 	offset += 4
 
 	// Version
@@ -301,7 +301,7 @@ func (c *Codec) EncodeData(seq uint64, payload []byte) ([]byte, error) {
 	buf := make([]byte, HeaderSize+payloadSize)
 
 	buf[0] = byte(MessageTypeData)
-	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize))
+	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize)) // #nosec G115 -- payload guarded by MaxPayloadSize check above, fits uint32
 	binary.BigEndian.PutUint64(buf[HeaderSize:], seq)
 	copy(buf[HeaderSize+8:], payload)
 
@@ -335,9 +335,7 @@ func (c *Codec) EncodeAlert(level AlertLevel, code AlertCode, description string
 	buf := make([]byte, HeaderSize+payloadSize)
 
 	buf[0] = byte(MessageTypeAlert)
-	// payloadSize is max 258 bytes, so safe to cast
-	//nolint:gosec // G115: payloadSize is bounded < 300
-	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize))
+	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize)) // #nosec G115 -- alert payloadSize is bounded < 300, fits uint32
 	buf[HeaderSize] = byte(level)
 	buf[HeaderSize+1] = byte(code)
 	buf[HeaderSize+2] = byte(len(description))
@@ -405,7 +403,7 @@ func (c *Codec) EncodeRekey(seq uint64, ciphertext []byte) ([]byte, error) {
 	buf := make([]byte, HeaderSize+payloadSize)
 
 	buf[0] = byte(MessageTypeRekey)
-	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize))
+	binary.BigEndian.PutUint32(buf[1:], uint32(payloadSize)) // #nosec G115 -- rekey payloadSize bounded by MaxMessageSize, fits uint32
 	binary.BigEndian.PutUint64(buf[HeaderSize:], seq)
 	copy(buf[HeaderSize+8:], ciphertext)
 

--- a/pkg/tunnel/dgram_cookie.go
+++ b/pkg/tunnel/dgram_cookie.go
@@ -55,7 +55,7 @@ func newCookieSigner(now func() time.Time) (*cookieSigner, error) {
 // issue returns a fresh cookie bound to addr at the current time.
 func (cs *cookieSigner) issue(addr net.Addr) []byte {
 	cookie := make([]byte, cookieSize)
-	binary.BigEndian.PutUint64(cookie[:cookieTimestampSize], uint64(cs.now().UnixNano()))
+	binary.BigEndian.PutUint64(cookie[:cookieTimestampSize], uint64(cs.now().UnixNano())) // #nosec G115 -- UnixNano is positive through year 2262, fits uint64
 	copy(cookie[cookieTimestampSize:], cs.mac(addr, cookie[:cookieTimestampSize]))
 	return cookie
 }
@@ -69,7 +69,7 @@ func (cs *cookieSigner) verify(addr net.Addr, cookie []byte) bool {
 	if !hmac.Equal(cookie[cookieTimestampSize:], cs.mac(addr, cookie[:cookieTimestampSize])) {
 		return false
 	}
-	issued := time.Unix(0, int64(binary.BigEndian.Uint64(cookie[:cookieTimestampSize])))
+	issued := time.Unix(0, int64(binary.BigEndian.Uint64(cookie[:cookieTimestampSize]))) // #nosec G115 -- timestamp we issued is positive through year 2262, fits int64
 	age := cs.now().Sub(issued)
 	return age >= 0 && age <= cookieLifetime
 }

--- a/pkg/tunnel/dgram_handshake.go
+++ b/pkg/tunnel/dgram_handshake.go
@@ -53,9 +53,9 @@ func fragmentHandshake(base protocol.DatagramHandshakeHeader, msg []byte, pad bo
 		}
 		h := base
 		h.Seq = seq
-		h.FragOffset = uint16(off)
-		h.FragLength = uint16(end - off)
-		h.TotalLength = uint16(total)
+		h.FragOffset = uint16(off)       // #nosec G115 -- offset bounded by handshake flight size (< 64KiB)
+		h.FragLength = uint16(end - off) // #nosec G115 -- fragment length bounded by MTU
+		h.TotalLength = uint16(total)    // #nosec G115 -- handshake flight bounded < 64KiB by protocol
 		frame, err := protocol.EncodeDatagramHandshake(h, msg[off:end])
 		if err != nil {
 			return nil, err

--- a/pkg/tunnel/handshake.go
+++ b/pkg/tunnel/handshake.go
@@ -575,7 +575,7 @@ func (h *Handshake) IsComplete() bool {
 func writeEncryptedRecord(w io.Writer, ciphertext []byte) error {
 	// Write length prefix
 	lenBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBuf, uint32(len(ciphertext)))
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(ciphertext))) // #nosec G115 -- record ciphertext bounded by MaxMessageSize, fits uint32
 	if _, err := w.Write(lenBuf); err != nil {
 		return err
 	}

--- a/pkg/tunnel/replay.go
+++ b/pkg/tunnel/replay.go
@@ -134,11 +134,14 @@ func (w *DatagramReplayWindow) advance(delta uint64) {
 	wordShift := delta / replayWordBits
 	bitShift := delta % replayWordBits
 	for i := len(w.bitmap) - 1; i >= 0; i-- {
-		src := uint64(i) - wordShift
 		var v uint64
-		if int64(src) >= 0 {
+		// Guard against unsigned underflow of src directly, rather than casting to
+		// int64. When wordShift > i the subtraction would wrap, so skip the word.
+		ui := uint64(i) // #nosec G115 -- loop index i is always >= 0
+		if ui >= wordShift {
+			src := ui - wordShift
 			v = w.bitmap[src] << bitShift
-			if bitShift != 0 && int64(src)-1 >= 0 {
+			if bitShift != 0 && src >= 1 {
 				v |= w.bitmap[src-1] >> (replayWordBits - bitShift)
 			}
 		}


### PR DESCRIPTION
## Summary
Raise the CI trust signal: gosec now actually fails the build, and FIPS + vet run in CI. Closes ROADMAP v0.0.10 #8.

## What changed
- **gosec gates CI**: dropped `-no-fail`. Every current finding is triaged with a justified `#nosec`: 13 bounded integer conversions (payload sizes capped by `MaxMessageSize`/`MaxPayloadSize`, MTU-bounded fragment fields, a non-negative loop index) and the KAT-nonce G407. The prior `//nolint:gosec` comments were inert for standalone gosec (it honors `#nosec`).
- **Found a latent CI bug**: removing `-no-fail` exposed that the `securego/gosec` Docker image's bundled Go was too old to load this `go 1.26` module, so gosec errored on package load and exited non-zero (0 findings, but a hard fail) - silently masked until now. Fixed by running gosec under a pinned Go 1.26 toolchain (`setup-go` + `go install gosec`).
- **One real cleanup**: rewrote a replay-window cast to test unsigned underflow directly instead of `int64(src)`, removing the conversion.
- **Reports survive failures**: `if: always()` on the sarif + report uploads.
- **FIPS job**: `go build/test -tags fips ./... -race`. **go vet**: plain and `-tags fips`.

## Verified
Locally: `gosec ./...` exits 0; vet (both tags) clean; `go test ./...` and `go test -tags fips ./... -race` pass. In CI: Security Scan now passes as a real 51s scan (was a 20s masked failure).

## Not included
Benchmark data-race item was already resolved (`atomic.Int64`). Endpoint authentication (the real "static key pinning") is designed and deferred to its own effort.