### PR TITLE
add server-side require-auth for static-key endpoint authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+### Added
+- **Server-side require-auth (`TransportConfig.RequireStaticAuth`, datagram `WithRequireStaticAuth`)**: a server that holds a static identity can now reject any client that does not authenticate it via static-key pinning, instead of admitting unpinned clients alongside pinned ones. On the stream path an unpinned client fails closed with `ErrStaticAuthRequired`; on the datagram path the responder drops the unauthenticated ClientHello and the dial fails at the retry ceiling. Requiring auth without a `StaticKeyPair` is a misconfiguration that fails closed with `ErrStaticAuthMisconfigured` (the stream listener at `Accept`, the datagram endpoint at construction). Default is unchanged: unpinned clients are still served.
+
 ## [0.0.12][] - 2026-06-19
 
 **Theme:** Endpoint authentication. Opt-in static-key server pinning on both the stream and datagram paths, a `quantum-tunnel keygen` CLI to mint and distribute identities, role and protocol-version transcript binding, and CI security hardening.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,7 +138,9 @@ The client encapsulates a second CH-KEM leg to the pinned key and folds the secr
 
 The wire alert stays generic, so a prober that guesses pins learns nothing.
 
-**Not yet provided**: client authentication and PSK-based mutual authentication (planned: v0.0.13). Static-key pinning authenticates the server to the client only; it does not let a server verify a client. For mutual authentication today, layer it externally.
+**Requiring authentication (server side)**: by default a server with a static identity still serves clients that do not pin it (the static leg is opt-in from the client). Set `TransportConfig.RequireStaticAuth` (stream) or `tunnel.WithRequireStaticAuth()` (datagram) to reject any client that does not authenticate the server, closing a silent downgrade where a misconfigured or stripped client connects unauthenticated. An unpinned client then fails closed: stream with `ErrStaticAuthRequired`, datagram as a retry-ceiling timeout. Requiring auth without a static key is a misconfiguration that fails closed (`ErrStaticAuthMisconfigured`). This requires clients to prove they used the server's public key; it is not client identity verification (the key is public).
+
+**Not yet provided**: client authentication and PSK-based mutual authentication (planned: v0.0.13). Static-key pinning authenticates the server to the client only; it does not let a server verify a client identity. For mutual authentication today, layer it externally.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -461,6 +461,10 @@ pinning (stream path) now closes it for the pinned-server case; the rest follows
 - [x] `quantum-tunnel keygen` CLI for static-key generation and pin distribution -
   writes a base64 secret seed (mode 0600) and public pin, prints an `SHA256:`
   fingerprint, and re-derives the pin from a seed via `--pub-from`
+- [x] Server-side require-auth (`TransportConfig.RequireStaticAuth`, datagram
+  `WithRequireStaticAuth`) - rejects unpinned clients with `ErrStaticAuthRequired`
+  (stream) or a retry-ceiling timeout (datagram); misconfiguration without a static
+  key fails closed with `ErrStaticAuthMisconfigured`
 - [ ] Document authentication modes in SECURITY.md
 
 **Reference:** WireGuard static key authentication, TLS 1.3 PSK mode (RFC 8446 Section 2.2)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -85,6 +85,15 @@ var (
 	// ErrServerKeyMismatch indicates the server did not prove possession of the
 	// pinned static key (wrong key, or static auth required but not negotiated).
 	ErrServerKeyMismatch = errors.New("protocol: server static key mismatch")
+
+	// ErrStaticAuthRequired indicates the server requires every client to
+	// authenticate it via static-key pinning, but the client sent no static
+	// ciphertext (an unpinned or downgraded client).
+	ErrStaticAuthRequired = errors.New("protocol: static-key authentication required")
+
+	// ErrStaticAuthMisconfigured indicates a server is set to require static-key
+	// authentication without holding a static identity to prove.
+	ErrStaticAuthMisconfigured = errors.New("protocol: require static auth set without a static key pair")
 )
 
 // Sentinel errors for tunnel operations

--- a/pkg/tunnel/datagram.go
+++ b/pkg/tunnel/datagram.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/sara-star-quant/quantum-go/internal/constants"
+	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
 	"github.com/sara-star-quant/quantum-go/pkg/chkem"
 	"github.com/sara-star-quant/quantum-go/pkg/crypto"
 	"github.com/sara-star-quant/quantum-go/pkg/protocol"
@@ -403,6 +404,11 @@ type DatagramEndpoint struct {
 	// initiator does not authenticate the server.
 	pinnedServerKey *chkem.PublicKey
 
+	// requireStaticAuth makes the responder reject any initiator that does not
+	// authenticate it via static-key pinning, set by WithRequireStaticAuth. It
+	// requires staticIdentity to be set.
+	requireStaticAuth bool
+
 	closeOnce sync.Once
 	done      chan struct{}
 }
@@ -459,6 +465,15 @@ func WithStaticIdentity(kp *chkem.KeyPair) DatagramEndpointOption {
 	return func(e *DatagramEndpoint) { e.staticIdentity = kp }
 }
 
+// WithRequireStaticAuth makes the responder reject any initiator that does not
+// authenticate it via static-key pinning. It requires WithStaticIdentity; an
+// endpoint set to require auth without an identity fails construction with
+// ErrStaticAuthMisconfigured. Unset, the endpoint admits unpinned initiators
+// alongside pinned ones.
+func WithRequireStaticAuth() DatagramEndpointOption {
+	return func(e *DatagramEndpoint) { e.requireStaticAuth = true }
+}
+
 // WithPinnedServerKey makes DialDatagram require the server to prove possession of
 // the given static public key; a wrong, absent, or stripped key fails the handshake
 // with ErrServerKeyMismatch. Unset, the initiator does not authenticate the server.
@@ -510,6 +525,9 @@ func newEndpoint(conn net.PacketConn, opts []DatagramEndpointOption) (*DatagramE
 	}
 	for _, opt := range opts {
 		opt(e)
+	}
+	if e.requireStaticAuth && e.staticIdentity == nil {
+		return nil, qerrors.ErrStaticAuthMisconfigured
 	}
 	// Resolve the half-open ceiling after opts: autoscale with core count unless an
 	// operator pinned it via WithMaxHalfOpen. The cookie-pressure water-mark and the

--- a/pkg/tunnel/dgram_handshake_wire.go
+++ b/pkg/tunnel/dgram_handshake_wire.go
@@ -99,6 +99,7 @@ func (e *DatagramEndpoint) startResponder(src net.Addr, ds *datagramSession, fir
 		return
 	}
 	session.StaticKeyPair = e.staticIdentity
+	session.RequireStaticAuth = e.requireStaticAuth
 	idx, err := e.registry.add(ds)
 	if err != nil {
 		e.registry.removeSource(src.String())

--- a/pkg/tunnel/dgram_static_auth_test.go
+++ b/pkg/tunnel/dgram_static_auth_test.go
@@ -14,11 +14,16 @@ import (
 // client session (nil on failure), the server session surfaced on acceptCh (nil
 // if the server never established), and the dial error.
 func dialDgramAuth(t *testing.T, seed uint64, drop, dup, reorder float64, serverKP *chkem.KeyPair, clientPin *chkem.PublicKey) (client, server *Session, dialErr error) {
+	return dialDgramAuthOpts(t, seed, drop, dup, reorder, serverKP, clientPin, false)
+}
+
+func dialDgramAuthOpts(t *testing.T, seed uint64, drop, dup, reorder float64, serverKP *chkem.KeyPair, clientPin *chkem.PublicKey, requireAuth bool) (client, server *Session, dialErr error) {
 	t.Helper()
 	connA, connB := memPipe(seed, drop, dup, reorder)
 	epA := mustEndpoint(t, connA)
 	epB := mustEndpoint(t, connB)
 	epB.staticIdentity = serverKP
+	epB.requireStaticAuth = requireAuth
 	epA.pinnedServerKey = clientPin
 	for _, ep := range []*DatagramEndpoint{epA, epB} {
 		ep.rtoInitial = 2 * time.Millisecond
@@ -111,5 +116,47 @@ func TestDgramStaticAuthServerServesUnpinnedClient(t *testing.T) {
 	}
 	if client.State() != SessionStateEstablished || server.State() != SessionStateEstablished {
 		t.Fatalf("not established: client=%v server=%v", client.State(), server.State())
+	}
+}
+
+func TestDgramRequireStaticAuthAcceptsPinnedClient(t *testing.T) {
+	serverKP, _, err := chkem.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	client, server, dialErr := dialDgramAuthOpts(t, 9, 0, 0, 0, serverKP, serverKP.PublicKey(), true)
+	if dialErr != nil {
+		t.Fatalf("require-auth with a pinned client failed: %v", dialErr)
+	}
+	if client == nil || server == nil {
+		t.Fatal("nil session(s)")
+	}
+	if client.State() != SessionStateEstablished || server.State() != SessionStateEstablished {
+		t.Fatalf("not established: client=%v server=%v", client.State(), server.State())
+	}
+}
+
+func TestDgramRequireStaticAuthRejectsUnpinnedClient(t *testing.T) {
+	serverKP, _, err := chkem.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	// Client does not pin: the responder drops its unauthenticated ClientHello, so
+	// the dial fails closed at the retry ceiling rather than establishing.
+	client, server, dialErr := dialDgramAuthOpts(t, 4, 0, 0, 0, serverKP, nil, true)
+	if dialErr == nil {
+		t.Fatal("require-auth responder established a session for an unpinned client")
+	}
+	if client != nil || server != nil {
+		t.Error("require-auth responder surfaced a session for an unpinned client")
+	}
+}
+
+func TestDgramRequireStaticAuthMisconfigured(t *testing.T) {
+	// WithRequireStaticAuth without WithStaticIdentity must fail construction.
+	connA, _ := memPipe(1, 0, 0, 0)
+	_, err := NewDatagramEndpoint(connA, WithRequireStaticAuth())
+	if !errors.Is(err, qerrors.ErrStaticAuthMisconfigured) {
+		t.Fatalf("misconfigured require-auth: got %v, want ErrStaticAuthMisconfigured", err)
 	}
 }

--- a/pkg/tunnel/handshake.go
+++ b/pkg/tunnel/handshake.go
@@ -366,6 +366,12 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 	}
 	h.session.RemotePublicKey = clientPublicKey
 
+	// If the server requires static-key authentication, reject any client that
+	// sent no static ciphertext (unpinned, or a MitM that stripped the field).
+	if h.session.RequireStaticAuth && len(msg.CHKEMStaticCiphertext) == 0 {
+		return qerrors.ErrStaticAuthRequired
+	}
+
 	// Static-key authentication: if we hold a static identity and the client sent
 	// a static ciphertext, decapsulate it. Only our static private key recovers
 	// the secret the client encapsulated to our pinned public key. ML-KEM implicit

--- a/pkg/tunnel/session.go
+++ b/pkg/tunnel/session.go
@@ -103,6 +103,10 @@ type Session struct {
 	// server to prove possession of (client side). Nil means unauthenticated.
 	PinnedServerKey *chkem.PublicKey
 
+	// RequireStaticAuth makes a responder reject any initiator that does not
+	// authenticate it via static-key pinning (server side). Requires StaticKeyPair.
+	RequireStaticAuth bool
+
 	// Master secret derived from CH-KEM
 	masterSecret []byte
 

--- a/pkg/tunnel/static_auth_test.go
+++ b/pkg/tunnel/static_auth_test.go
@@ -2,6 +2,7 @@ package tunnel_test
 
 import (
 	"errors"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -135,5 +136,69 @@ func TestStaticAuthServerServesUnpinnedClient(t *testing.T) {
 	}
 	if !accepted {
 		t.Error("server did not accept an unpinned client")
+	}
+}
+
+func TestStaticAuthRequiredAcceptsPinnedClient(t *testing.T) {
+	serverKP, _, err := chkem.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	serverCfg := tunnel.DefaultTransportConfig()
+	serverCfg.StaticKeyPair = serverKP
+	serverCfg.RequireStaticAuth = true
+	clientCfg := tunnel.DefaultTransportConfig()
+	clientCfg.PinnedServerKey = serverKP.PublicKey()
+
+	clientErr, accepted := runStaticAuthHandshake(t, serverCfg, clientCfg)
+	if clientErr != nil {
+		t.Fatalf("require-auth with a pinned client failed: %v", clientErr)
+	}
+	if !accepted {
+		t.Error("require-auth server did not accept a pinned client")
+	}
+}
+
+func TestStaticAuthRequiredRejectsUnpinnedClient(t *testing.T) {
+	serverKP, _, err := chkem.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	serverCfg := tunnel.DefaultTransportConfig()
+	serverCfg.StaticKeyPair = serverKP
+	serverCfg.RequireStaticAuth = true
+
+	// Client sends no static ciphertext; the server must reject it.
+	clientErr, accepted := runStaticAuthHandshake(t, serverCfg, tunnel.DefaultTransportConfig())
+	if clientErr == nil {
+		t.Fatal("require-auth server accepted an unpinned client")
+	}
+	if accepted {
+		t.Error("require-auth server established a session for an unpinned client")
+	}
+}
+
+func TestStaticAuthRequiredMisconfiguredRejected(t *testing.T) {
+	// RequireStaticAuth without a StaticKeyPair is a server misconfiguration; the
+	// listener must fail closed rather than admit anyone.
+	listener, err := tunnel.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	cfg := tunnel.DefaultTransportConfig()
+	cfg.RequireStaticAuth = true // no StaticKeyPair
+	listener.SetConfig(cfg)
+
+	go func() {
+		c, derr := net.Dial("tcp", listener.Addr().String())
+		if derr == nil {
+			_ = c.Close()
+		}
+	}()
+
+	_, acceptErr := listener.Accept()
+	if !errors.Is(acceptErr, qerrors.ErrStaticAuthMisconfigured) {
+		t.Fatalf("misconfigured require-auth: got %v, want ErrStaticAuthMisconfigured", acceptErr)
 	}
 }

--- a/pkg/tunnel/transport.go
+++ b/pkg/tunnel/transport.go
@@ -75,6 +75,12 @@ type TransportConfig struct {
 	// key the client requires the server to prove possession of. Nil means
 	// unauthenticated (default).
 	PinnedServerKey *chkem.PublicKey
+
+	// RequireStaticAuth, when set on a server (Listen), rejects any client that
+	// does not authenticate the server via static-key pinning. It requires
+	// StaticKeyPair to be set. Default false admits unpinned clients alongside
+	// pinned ones.
+	RequireStaticAuth bool
 }
 
 // RateLimitConfig holds configuration for rate limiting.
@@ -732,6 +738,9 @@ func (l *Listener) checkIPRateLimit(conn net.Conn, remoteIP string) (net.Conn, e
 
 // createSession creates a new responder session with observer.
 func (l *Listener) createSession() (*Session, error) {
+	if l.config.RequireStaticAuth && l.config.StaticKeyPair == nil {
+		return nil, qerrors.ErrStaticAuthMisconfigured
+	}
 	session, err := NewSession(RoleResponder)
 	if err != nil {
 		return nil, err
@@ -741,6 +750,7 @@ func (l *Listener) createSession() (*Session, error) {
 		observer.OnSessionStart()
 	}
 	session.StaticKeyPair = l.config.StaticKeyPair
+	session.RequireStaticAuth = l.config.RequireStaticAuth
 	return session, nil
 }
 


### PR DESCRIPTION
First v0.0.13 item: server-side require-auth.

A server that holds a static identity previously admitted unpinned clients alongside pinned ones, so a misconfigured or downgraded client could connect unauthenticated without the server noticing. `TransportConfig.RequireStaticAuth` (stream) and `tunnel.WithRequireStaticAuth()` (datagram) make the responder reject any client that sends no static ciphertext.

- Stream: an unpinned client fails closed with `ErrStaticAuthRequired`.
- Datagram: the responder drops the unauthenticated ClientHello, so the dial fails at the retry ceiling.
- Misconfiguration (require-auth without a `StaticKeyPair`) fails closed with `ErrStaticAuthMisconfigured` - the stream listener at `Accept`, the datagram endpoint at construction.
- Default behavior is preserved: a server still serves unpinned clients unless it opts in.

This requires clients to prove they used the server's public key; it is not client identity verification (the key is public). That, plus PSK mutual-auth, remains the v0.0.13 scope.

## Tests
Stream and datagram each get: require-auth accepts a pinned client, rejects an unpinned client, and rejects the misconfigured (no-key) setup. Full `go test ./...`, `go vet`, `gofmt`, and `golangci-lint` are clean locally.

## Docs
CHANGELOG (Unreleased), ROADMAP auth checklist, and SECURITY.md Authentication modes all updated.
