### PR TITLE
add the KEM-suite abstraction with CH-KEM-v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+### Added
+- **KEM-suite abstraction (foundation for crypto-agility)**: `pkg/chkem` now exposes a `Suite` interface, a `SuiteID` wire identifier, and a registry, with the existing CH-KEM (ML-KEM-1024 + X25519 + SHAKE-256) registered as `SuiteCHKEMv1` (the default). The v1 suite delegates to the existing functions, so output is byte-for-byte unchanged; this is the additive first step toward negotiated, pluggable KEMs (X-Wing interop, HQC diversification). No wire or behavior change yet.
+
 ### Changed
 - **License changed from MIT to Apache License 2.0.** Apache 2.0 adds an express patent grant and patent-retaliation clause, which matters in the patent-heavy post-quantum cryptography space, and is the standard for cryptographic and infrastructure libraries. Added a `NOTICE` file. The library stays permissive and commercial-friendly.
 

--- a/pkg/chkem/suite.go
+++ b/pkg/chkem/suite.go
@@ -1,0 +1,98 @@
+package chkem
+
+import "github.com/sara-star-quant/quantum-go/internal/constants"
+
+// SuiteID is the 2-byte wire identifier of a KEM suite. It is negotiated in the
+// handshake so peers can agree on the KEM construction (the cascade, the combiner)
+// the way they already agree on an AEAD cipher suite.
+type SuiteID uint16
+
+const (
+	// SuiteCHKEMv1 is the original Cascaded Hybrid KEM: ML-KEM-1024 + X25519 with a
+	// SHAKE-256 combiner. It is the default and mandatory-to-implement suite.
+	SuiteCHKEMv1 SuiteID = 0x0001
+)
+
+// Suite is a pluggable KEM construction. Every suite derives a 32-byte shared
+// secret (constants.CHKEMSharedSecretSize), so all downstream KDF and handshake
+// code is suite-independent; only the public-key/ciphertext sizes and the internal
+// construction differ. The methods mirror the package-level CH-KEM functions so a
+// caller can hold a Suite instead of calling the fixed construction directly.
+type Suite interface {
+	// ID returns the suite's wire identifier.
+	ID() SuiteID
+	// GenerateKeyPair generates a fresh ephemeral key pair.
+	GenerateKeyPair() (*KeyPair, error)
+	// GenerateStaticKeyPair generates a long-term identity key pair and its seed.
+	GenerateStaticKeyPair() (*KeyPair, []byte, error)
+	// ParseKeyPair reconstructs a key pair from a SeedSize-byte seed.
+	ParseKeyPair(seed []byte) (*KeyPair, error)
+	// Encapsulate produces a ciphertext and a 32-byte shared secret for the recipient.
+	Encapsulate(recipient *PublicKey, role Role) (*Ciphertext, []byte, error)
+	// Decapsulate recovers the 32-byte shared secret from a ciphertext.
+	Decapsulate(ct *Ciphertext, kp *KeyPair, role Role) ([]byte, error)
+	// ParsePublicKey parses a PublicKeySize-byte public key.
+	ParsePublicKey(data []byte) (*PublicKey, error)
+	// ParseCiphertext parses a CiphertextSize-byte ciphertext.
+	ParseCiphertext(data []byte) (*Ciphertext, error)
+	// PublicKeySize is the serialized public-key length in bytes.
+	PublicKeySize() int
+	// CiphertextSize is the serialized ciphertext length in bytes.
+	CiphertextSize() int
+	// SeedSize is the static-identity seed length in bytes.
+	SeedSize() int
+	// IsFIPSApproved reports whether the suite is allowed in FIPS mode.
+	IsFIPSApproved() bool
+}
+
+// chkemV1 adapts the original CH-KEM construction (the package-level functions) to
+// the Suite interface. It delegates verbatim, so its output is byte-for-byte the
+// pre-suite CH-KEM.
+type chkemV1 struct{}
+
+func (chkemV1) ID() SuiteID { return SuiteCHKEMv1 }
+
+func (chkemV1) GenerateKeyPair() (*KeyPair, error) { return GenerateKeyPair() }
+
+func (chkemV1) GenerateStaticKeyPair() (*KeyPair, []byte, error) { return GenerateStaticKeyPair() }
+
+func (chkemV1) ParseKeyPair(seed []byte) (*KeyPair, error) { return ParseKeyPair(seed) }
+
+func (chkemV1) Encapsulate(recipient *PublicKey, role Role) (*Ciphertext, []byte, error) {
+	return Encapsulate(recipient, role)
+}
+
+func (chkemV1) Decapsulate(ct *Ciphertext, kp *KeyPair, role Role) ([]byte, error) {
+	return Decapsulate(ct, kp, role)
+}
+
+func (chkemV1) ParsePublicKey(data []byte) (*PublicKey, error) { return ParsePublicKey(data) }
+
+func (chkemV1) ParseCiphertext(data []byte) (*Ciphertext, error) { return ParseCiphertext(data) }
+
+func (chkemV1) PublicKeySize() int { return constants.CHKEMPublicKeySize }
+
+func (chkemV1) CiphertextSize() int { return constants.CHKEMCiphertextSize }
+
+func (chkemV1) SeedSize() int { return StaticKeySeedSize }
+
+// IsFIPSApproved preserves the pre-suite FIPS behavior: the FIPS build handshakes
+// with CH-KEM-v1 today (it has no KEM-level FIPS gate), so v1 stays allowed. The
+// hybrid uses X25519, so this is the project's operational posture, not a strict
+// FIPS 140-3 algorithm claim.
+func (chkemV1) IsFIPSApproved() bool { return true }
+
+// registry maps a SuiteID to its implementation.
+var registry = map[SuiteID]Suite{
+	SuiteCHKEMv1: chkemV1{},
+}
+
+// DefaultSuite returns the default KEM suite (CH-KEM-v1). It is the suite used when
+// no negotiation has selected another.
+func DefaultSuite() Suite { return registry[SuiteCHKEMv1] }
+
+// GetSuite returns the registered suite for id, or false if unknown.
+func GetSuite(id SuiteID) (Suite, bool) {
+	s, ok := registry[id]
+	return s, ok
+}

--- a/pkg/chkem/suite_test.go
+++ b/pkg/chkem/suite_test.go
@@ -1,0 +1,95 @@
+package chkem
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+)
+
+// TestDefaultSuiteIsCHKEMv1 checks the registry wiring.
+func TestDefaultSuiteIsCHKEMv1(t *testing.T) {
+	if DefaultSuite().ID() != SuiteCHKEMv1 {
+		t.Fatalf("default suite id = %#x, want SuiteCHKEMv1", DefaultSuite().ID())
+	}
+	if _, ok := GetSuite(SuiteCHKEMv1); !ok {
+		t.Fatal("SuiteCHKEMv1 not registered")
+	}
+	if _, ok := GetSuite(0xFFFF); ok {
+		t.Fatal("unknown suite id resolved")
+	}
+}
+
+// TestSuiteSizesMatchConstants checks the v1 suite reports the existing fixed sizes.
+func TestSuiteSizesMatchConstants(t *testing.T) {
+	s := DefaultSuite()
+	if s.PublicKeySize() != constants.CHKEMPublicKeySize {
+		t.Errorf("PublicKeySize = %d, want %d", s.PublicKeySize(), constants.CHKEMPublicKeySize)
+	}
+	if s.CiphertextSize() != constants.CHKEMCiphertextSize {
+		t.Errorf("CiphertextSize = %d, want %d", s.CiphertextSize(), constants.CHKEMCiphertextSize)
+	}
+	if s.SeedSize() != StaticKeySeedSize {
+		t.Errorf("SeedSize = %d, want %d", s.SeedSize(), StaticKeySeedSize)
+	}
+}
+
+// TestV1SuiteEquivalentToPackageFuncs proves the v1 suite is the *same construction*
+// as the package-level CH-KEM: a ciphertext sealed through the suite decapsulates
+// with the package Decapsulate (and vice versa) to the same secret, and a seed
+// reconstructs the identical public key both ways. This is the byte-identical
+// guarantee for Phase 1 - the abstraction adds no behavior.
+func TestV1SuiteEquivalentToPackageFuncs(t *testing.T) {
+	s := DefaultSuite()
+
+	// Deterministic identity: same seed -> same public key bytes via suite or func.
+	_, seed, err := s.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	kpSuite, err := s.ParseKeyPair(seed)
+	if err != nil {
+		t.Fatalf("suite ParseKeyPair: %v", err)
+	}
+	kpFunc, err := ParseKeyPair(seed)
+	if err != nil {
+		t.Fatalf("ParseKeyPair: %v", err)
+	}
+	if !bytes.Equal(kpSuite.PublicKey().Bytes(), kpFunc.PublicKey().Bytes()) {
+		t.Fatal("suite and package ParseKeyPair produced different public keys")
+	}
+
+	// Suite seals -> package opens, same secret.
+	ct, ssSeal, err := s.Encapsulate(kpFunc.PublicKey(), RoleResponder)
+	if err != nil {
+		t.Fatalf("suite Encapsulate: %v", err)
+	}
+	if len(ssSeal) != constants.CHKEMSharedSecretSize {
+		t.Fatalf("shared secret size = %d, want %d", len(ssSeal), constants.CHKEMSharedSecretSize)
+	}
+	ssOpen, err := Decapsulate(ct, kpFunc, RoleInitiator)
+	if err != nil {
+		t.Fatalf("Decapsulate: %v", err)
+	}
+	if !bytes.Equal(ssSeal, ssOpen) {
+		t.Fatal("suite-sealed ciphertext did not open to the same secret via the package func")
+	}
+
+	// Package seals -> suite opens, same secret. Confirms a wire ciphertext parsed
+	// through the suite is interoperable with the fixed construction.
+	ct2, ssSeal2, err := Encapsulate(kpFunc.PublicKey(), RoleResponder)
+	if err != nil {
+		t.Fatalf("Encapsulate: %v", err)
+	}
+	parsed, err := s.ParseCiphertext(ct2.Bytes())
+	if err != nil {
+		t.Fatalf("suite ParseCiphertext: %v", err)
+	}
+	ssOpen2, err := s.Decapsulate(parsed, kpSuite, RoleInitiator)
+	if err != nil {
+		t.Fatalf("suite Decapsulate: %v", err)
+	}
+	if !bytes.Equal(ssSeal2, ssOpen2) {
+		t.Fatal("package-sealed ciphertext did not open to the same secret via the suite")
+	}
+}


### PR DESCRIPTION
First step of the KEM-suite agility plan (the foundational flexibility lever): make the KEM pluggable. Additive only - no existing code touched, no wire/behavior change.

## What
`pkg/chkem` gains:
- `Suite` interface covering the CH-KEM surface (generate/static/parse/encapsulate/decapsulate + sizes + FIPS hook); every suite derives a 32-byte secret, so all downstream KDF/handshake code stays suite-independent.
- `SuiteID` (2-byte wire id) and a registry; `DefaultSuite()` / `GetSuite(id)`.
- `SuiteCHKEMv1 = 0x0001`: the existing ML-KEM-1024 + X25519 + SHAKE-256 construction, registered as the default and mandatory suite. The adapter delegates verbatim to the existing package functions, so output is byte-for-byte unchanged.

## Why this split
"Shared code first, then consumers." This PR establishes the abstraction in isolation (reviewable, zero risk). The next phase wires negotiation (KEM-suite fields in ClientHello/ServerHello, length-prefixed material, HelloRetryRequest, protocol 4.0) and routes the call sites; the phase after adds X-Wing (standardized interop). HQC stays deferred (exceeds the datagram fragmentation cap; not yet in circl).

## Tests
`TestV1SuiteEquivalentToPackageFuncs` proves a suite-sealed ciphertext opens with the package `Decapsulate` and vice versa (the byte-identical guarantee), plus registry wiring and size/seed accessors. Full `go test ./...`, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 all clean.
