### PR TITLE
route session KEM operations through the suite

### DIFF
--- a/pkg/tunnel/dgram_rekey.go
+++ b/pkg/tunnel/dgram_rekey.go
@@ -124,11 +124,11 @@ func (s *Session) respondToDatagramRekey(epoch uint8, initBody []byte) (respBody
 	if err != nil {
 		return nil, 0, err
 	}
-	pub, err := chkem.ParsePublicKey(pubBytes)
+	pub, err := s.kemSuite.ParsePublicKey(pubBytes)
 	if err != nil {
 		return nil, 0, err
 	}
-	ct, fresh, err := chkem.Encapsulate(pub, chkem.RoleResponder)
+	ct, fresh, err := s.kemSuite.Encapsulate(pub, chkem.RoleResponder)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -157,11 +157,11 @@ func (s *Session) completeDatagramRekey(epoch uint8, respBody []byte, kp *chkem.
 	if err != nil {
 		return err
 	}
-	ct, err := chkem.ParseCiphertext(ctBytes)
+	ct, err := s.kemSuite.ParseCiphertext(ctBytes)
 	if err != nil {
 		return err
 	}
-	fresh, err := chkem.Decapsulate(ct, kp, chkem.RoleInitiator)
+	fresh, err := s.kemSuite.Decapsulate(ct, kp, chkem.RoleInitiator)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c *DatagramConn) Rekey() error {
 	}
 	defer c.ds.endRekey()
 
-	kp, err := chkem.GenerateKeyPair()
+	kp, err := s.kemSuite.GenerateKeyPair()
 	if err != nil {
 		return err
 	}

--- a/pkg/tunnel/handshake.go
+++ b/pkg/tunnel/handshake.go
@@ -164,7 +164,7 @@ func (h *Handshake) CreateClientHello() ([]byte, error) {
 	// Static-key authentication: encapsulate to the pinned server static key so
 	// only the holder of the matching private key can derive the same secret.
 	if h.session.PinnedServerKey != nil {
-		staticCT, staticSecret, err := chkem.Encapsulate(h.session.PinnedServerKey, chkem.RoleInitiator)
+		staticCT, staticSecret, err := h.session.kemSuite.Encapsulate(h.session.PinnedServerKey, chkem.RoleInitiator)
 		if err != nil {
 			return nil, err
 		}
@@ -218,12 +218,12 @@ func (h *Handshake) ProcessServerHello(data []byte) error {
 	h.serverRandom = msg.Random
 
 	// Always decapsulate (server always sends real ciphertext now)
-	ct, err := chkem.ParseCiphertext(msg.CHKEMCiphertext)
+	ct, err := h.session.kemSuite.ParseCiphertext(msg.CHKEMCiphertext)
 	if err != nil {
 		return err
 	}
 
-	freshSecret, err := chkem.Decapsulate(ct, h.session.LocalKeyPair, chkem.RoleInitiator)
+	freshSecret, err := h.session.kemSuite.Decapsulate(ct, h.session.LocalKeyPair, chkem.RoleInitiator)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 	}
 
 	// Always parse client's public key (needed for fresh KEM exchange even during resumption)
-	clientPublicKey, err := chkem.ParsePublicKey(msg.CHKEMPublicKey)
+	clientPublicKey, err := h.session.kemSuite.ParsePublicKey(msg.CHKEMPublicKey)
 	if err != nil {
 		return err
 	}
@@ -396,11 +396,11 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 	// rejection means a wrong key yields a pseudo-random secret (no error/oracle);
 	// the mismatch surfaces later as a Finished MAC failure.
 	if h.session.StaticKeyPair != nil && len(msg.CHKEMStaticCiphertext) > 0 {
-		staticCT, err := chkem.ParseCiphertext(msg.CHKEMStaticCiphertext)
+		staticCT, err := h.session.kemSuite.ParseCiphertext(msg.CHKEMStaticCiphertext)
 		if err != nil {
 			return err
 		}
-		staticSecret, err := chkem.Decapsulate(staticCT, h.session.StaticKeyPair, chkem.RoleResponder)
+		staticSecret, err := h.session.kemSuite.Decapsulate(staticCT, h.session.StaticKeyPair, chkem.RoleResponder)
 		if err != nil {
 			return err
 		}
@@ -440,7 +440,7 @@ func (h *Handshake) CreateServerHello() ([]byte, error) {
 	h.serverRandom = crypto.MustSecureRandomBytes(32)
 
 	// Always perform fresh KEM exchange (even during resumption for forward secrecy)
-	ct, freshSecret, err := chkem.Encapsulate(h.session.RemotePublicKey, chkem.RoleResponder)
+	ct, freshSecret, err := h.session.kemSuite.Encapsulate(h.session.RemotePublicKey, chkem.RoleResponder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tunnel/session.go
+++ b/pkg/tunnel/session.go
@@ -89,6 +89,11 @@ type Session struct {
 	// Selected cipher suite
 	CipherSuite constants.CipherSuite
 
+	// kemSuite is the KEM construction this session uses (CH-KEM-v1 by default).
+	// All ephemeral KEM operations route through it; negotiation may select another
+	// suite once wire support lands. The static-auth leg uses the pinned key's suite.
+	kemSuite chkem.Suite
+
 	// Local key pair for this session
 	LocalKeyPair *chkem.KeyPair
 
@@ -215,8 +220,9 @@ func NewSession(role Role) (*Session, error) {
 		return nil, err
 	}
 
-	// Generate local key pair
-	keyPair, err := chkem.GenerateKeyPair()
+	// Generate local key pair using the default KEM suite.
+	suite := chkem.DefaultSuite()
+	keyPair, err := suite.GenerateKeyPair()
 	if err != nil {
 		return nil, err
 	}
@@ -224,6 +230,7 @@ func NewSession(role Role) (*Session, error) {
 	s := &Session{
 		ID:           sessionID,
 		Role:         role,
+		kemSuite:     suite,
 		LocalKeyPair: keyPair,
 		replayWindow: NewReplayWindow(),
 		CreatedAt:    time.Now(),
@@ -666,7 +673,7 @@ func (s *Session) InitiateRekey() ([]byte, uint64, error) {
 	}
 
 	// Generate new keypair for rekey
-	newKeyPair, err := chkem.GenerateKeyPair()
+	newKeyPair, err := s.kemSuite.GenerateKeyPair()
 	if err != nil {
 		return nil, 0, err
 	}
@@ -693,13 +700,13 @@ func (s *Session) PrepareRekeyResponse(newPublicKeyBytes []byte, activationSeq u
 	}
 
 	// Parse the new public key
-	newPublicKey, err := chkem.ParsePublicKey(newPublicKeyBytes)
+	newPublicKey, err := s.kemSuite.ParsePublicKey(newPublicKeyBytes)
 	if err != nil {
 		return nil, err
 	}
 
 	// Encapsulate to the new public key
-	ciphertext, freshSecret, err := chkem.Encapsulate(newPublicKey, chkem.RoleResponder)
+	ciphertext, freshSecret, err := s.kemSuite.Encapsulate(newPublicKey, chkem.RoleResponder)
 	if err != nil {
 		return nil, err
 	}
@@ -754,13 +761,13 @@ func (s *Session) ProcessRekeyResponse(ciphertextBytes []byte) error {
 	}
 
 	// Parse ciphertext
-	ciphertext, err := chkem.ParseCiphertext(ciphertextBytes)
+	ciphertext, err := s.kemSuite.ParseCiphertext(ciphertextBytes)
 	if err != nil {
 		return err
 	}
 
 	// Decapsulate using pending keypair
-	freshSecret, err := chkem.Decapsulate(ciphertext, s.pendingRekeyKeyPair, chkem.RoleInitiator)
+	freshSecret, err := s.kemSuite.Decapsulate(ciphertext, s.pendingRekeyKeyPair, chkem.RoleInitiator)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Initial KEM-suite agility: thread the `chkem.Suite` through the session. Byte-identical, no wire change.

## What
- `Session` gains a `kemSuite chkem.Suite` field, defaulting to `chkem.DefaultSuite()` (CH-KEM-v1).
- The session's ephemeral KEM call sites route through `kemSuite` instead of the package functions: handshake key generation, encapsulate/decapsulate, public-key/ciphertext parsing, and both the stream and datagram rekey paths.

## Why
The registry holds only CH-KEM-v1, so this is a pure refactor with byte-identical behavior. It threads the suite to the one place the next change (wire negotiation) will set from the handshake. Keeping it separate from the wire change keeps both reviewable.

The static-auth leg routes through the session suite for now (both legs are v1); dispatching it on the pinned key's own suite lands with X-Wing, where a pin can differ from the ephemeral suite.

## Tests
Existing handshake, rekey, and datagram round-trips stay green (the byte-identical guarantee). Full `go test ./...`, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 all clean.
