### PR TITLE
add the HelloRetryRequest wire message

### DIFF
--- a/pkg/protocol/codec.go
+++ b/pkg/protocol/codec.go
@@ -386,6 +386,32 @@ func (c *Codec) DecodeServerHello(data []byte) (*ServerHello, error) {
 }
 
 // EncodeFinished serializes a Finished message (client or server).
+// EncodeHelloRetryRequest serializes a HelloRetryRequest (version + KEM suite).
+func (c *Codec) EncodeHelloRetryRequest(m *HelloRetryRequest) ([]byte, error) {
+	const payloadSize = 2 + 2 // version + kem suite
+	buf := make([]byte, HeaderSize+payloadSize)
+	buf[0] = byte(MessageTypeHelloRetryRequest)
+	binary.BigEndian.PutUint32(buf[1:], payloadSize)
+	buf[HeaderSize] = m.Version.Major
+	buf[HeaderSize+1] = m.Version.Minor
+	binary.BigEndian.PutUint16(buf[HeaderSize+2:], m.KEMSuite)
+	return buf, nil
+}
+
+// DecodeHelloRetryRequest deserializes a HelloRetryRequest.
+func (c *Codec) DecodeHelloRetryRequest(data []byte) (*HelloRetryRequest, error) {
+	if len(data) < HeaderSize+4 {
+		return nil, qerrors.ErrInvalidMessage
+	}
+	if MessageType(data[0]) != MessageTypeHelloRetryRequest {
+		return nil, qerrors.ErrInvalidMessage
+	}
+	return &HelloRetryRequest{
+		Version:  Version{Major: data[HeaderSize], Minor: data[HeaderSize+1]},
+		KEMSuite: binary.BigEndian.Uint16(data[HeaderSize+2:]),
+	}, nil
+}
+
 func (c *Codec) EncodeFinished(msgType MessageType, verifyData []byte) ([]byte, error) {
 	if len(verifyData) != 32 {
 		return nil, qerrors.ErrInvalidMessage

--- a/pkg/protocol/codec_test.go
+++ b/pkg/protocol/codec_test.go
@@ -1226,3 +1226,29 @@ func TestServerHelloKEMSuiteRoundTrip(t *testing.T) {
 		t.Error("cipher suite mismatch after the inserted KEM-suite field")
 	}
 }
+
+func TestHelloRetryRequestRoundTrip(t *testing.T) {
+	codec := protocol.NewCodec()
+	original := &protocol.HelloRetryRequest{
+		Version:  protocol.Current,
+		KEMSuite: 0x0001,
+	}
+	encoded, err := codec.EncodeHelloRetryRequest(original)
+	if err != nil {
+		t.Fatalf("EncodeHelloRetryRequest: %v", err)
+	}
+	if protocol.MessageType(encoded[0]) != protocol.MessageTypeHelloRetryRequest {
+		t.Errorf("message type = %#x, want HelloRetryRequest", encoded[0])
+	}
+	decoded, err := codec.DecodeHelloRetryRequest(encoded)
+	if err != nil {
+		t.Fatalf("DecodeHelloRetryRequest: %v", err)
+	}
+	if decoded.Version != original.Version || decoded.KEMSuite != original.KEMSuite {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, original)
+	}
+	// A truncated payload is rejected.
+	if _, err := codec.DecodeHelloRetryRequest(encoded[:protocol.HeaderSize+2]); err == nil {
+		t.Error("expected error for a truncated HelloRetryRequest")
+	}
+}

--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -35,6 +35,9 @@ const (
 	MessageTypeClientFinished MessageType = 0x03
 	// MessageTypeServerFinished confirms handshake completion from server.
 	MessageTypeServerFinished MessageType = 0x04
+	// MessageTypeHelloRetryRequest asks the client to retry the ClientHello with a
+	// server-selected KEM suite (sent instead of ServerHello on a suite mismatch).
+	MessageTypeHelloRetryRequest MessageType = 0x05
 
 	// MessageTypeData carries encrypted application data.
 	MessageTypeData MessageType = 0x10
@@ -167,6 +170,18 @@ type ServerHello struct {
 
 	// Selected cipher suite
 	CipherSuite constants.CipherSuite
+}
+
+// HelloRetryRequest is sent by the responder instead of ServerHello when it does
+// not support the KEM suite the client's key share used. It names a mutually
+// supported suite the client should retry with. It is unencrypted (pre-key) and is
+// bound into the handshake transcript via the RFC 8446 4.4.1 synthetic message hash.
+type HelloRetryRequest struct {
+	// Protocol version selected by the server
+	Version Version
+
+	// KEMSuite is the suite the client should use for its retried key share.
+	KEMSuite uint16
 }
 
 // ClientFinished confirms the handshake from the client side.


### PR DESCRIPTION
First, additive step of KEM-suite HelloRetryRequest (2C): the wire message definition.

## What
- `MessageTypeHelloRetryRequest = 0x05`.
- `HelloRetryRequest{Version, KEMSuite uint16}` struct + codec encode/decode (mirrors the Finished codec).
- Round-trip + truncation-rejection test.

## Why split
The HRR handshake logic (server short-circuit + send, client retry, the RFC 8446 4.4.1 synthetic-hash transcript) and the stream/datagram FSM wiring are the security-critical part and land in a separate change. This PR is the additive wire stub they build on - nothing produces or consumes it yet, so there is no behavior change and no risk. Same 'shared stub first' split as the KEM-suite foundation.

## Tests
`TestHelloRetryRequestRoundTrip` (round-trip + truncated-payload rejection). Full `go test ./...`, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 clean.