### PR TITLE
implement HelloRetryRequest on the stream handshake

### DIFF
--- a/pkg/tunnel/handshake.go
+++ b/pkg/tunnel/handshake.go
@@ -94,6 +94,16 @@ type Handshake struct {
 	// Transcript for verify_data computation
 	transcript bytes.Buffer
 
+	// HelloRetryRequest state. firstClientHello is the framed bytes of the first
+	// ClientHello, kept so the RFC 8446 4.4.1 synthetic message hash can replace it
+	// in the transcript on a retry. sendHRR (server) signals the driver to answer
+	// the current ClientHello with a HelloRetryRequest for hrrSuite instead of a
+	// ServerHello. hrrDone bounds the exchange to a single retry on both peers.
+	firstClientHello []byte
+	sendHRR          bool
+	hrrSuite         chkem.SuiteID
+	hrrDone          bool
+
 	// Resumption state
 	ticket        []byte         // Client ticket to send
 	ticketSecret  []byte         // Initiator's secret for the ticket
@@ -150,8 +160,11 @@ func (h *Handshake) CreateClientHello() ([]byte, error) {
 		return nil, qerrors.ErrInvalidState
 	}
 
-	// Generate client random
-	h.clientRandom = crypto.MustSecureRandomBytes(32)
+	// Generate client random. Keep it stable across a HelloRetryRequest retry so the
+	// only difference between ClientHello1 and ClientHello2 is the KEM suite + share.
+	if h.clientRandom == nil {
+		h.clientRandom = crypto.MustSecureRandomBytes(32)
+	}
 
 	msg := &protocol.ClientHello{
 		Version:        protocol.Current,
@@ -186,13 +199,79 @@ func (h *Handshake) CreateClientHello() ([]byte, error) {
 		return nil, err
 	}
 
-	// Add to transcript
+	// Add to transcript, and remember the first ClientHello frame for the synthetic
+	// message hash if a HelloRetryRequest follows.
 	h.transcript.Write(data)
+	if h.firstClientHello == nil {
+		h.firstClientHello = data
+	}
 
 	h.state = HandshakeStateClientHelloSent
 	h.session.SetState(SessionStateHandshaking)
 
 	return data, nil
+}
+
+// ProcessHelloRetryRequest handles a HelloRetryRequest (initiator): adopt the KEM
+// suite the server chose, regenerate the ephemeral key share in it, rewrite the
+// transcript with the RFC 8446 4.4.1 synthetic message hash, and re-arm so the
+// driver re-sends a ClientHello. Bounded to one retry.
+func (h *Handshake) ProcessHelloRetryRequest(data []byte) error {
+	if h.state != HandshakeStateClientHelloSent {
+		return qerrors.ErrInvalidState
+	}
+	if h.hrrDone {
+		return qerrors.ErrUnsupportedKEMSuite // a second HelloRetryRequest is not allowed
+	}
+	msg, err := h.codec.DecodeHelloRetryRequest(data)
+	if err != nil {
+		return err
+	}
+	if !msg.Version.IsCompatible(protocol.Current) {
+		return qerrors.ErrUnsupportedVersion
+	}
+	suite, err := resolveKEMSuite(msg.KEMSuite)
+	if err != nil {
+		return err
+	}
+	// The retried suite must be one we offered, or the server is steering us off-list.
+	if !offeredKEMSuite(msg.KEMSuite) {
+		return qerrors.ErrUnsupportedKEMSuite
+	}
+
+	// Adopt the suite and regenerate the ephemeral key share in it.
+	newKeyPair, err := suite.GenerateKeyPair()
+	if err != nil {
+		return err
+	}
+	if h.session.LocalKeyPair != nil {
+		h.session.LocalKeyPair.Zeroize()
+	}
+	h.session.kemSuite = suite
+	h.session.LocalKeyPair = newKeyPair
+
+	// Synthetic transcript: SHA3-256(ClientHello1) || HelloRetryRequest, replacing the
+	// raw ClientHello1, so the original advertisement is bound even across the retry.
+	if err := h.replaceFirstHelloWithHash(data); err != nil {
+		return err
+	}
+	h.hrrDone = true
+	h.state = HandshakeStateInitial // re-arm CreateClientHello for the retried hello
+	return nil
+}
+
+// replaceFirstHelloWithHash rewrites the transcript per RFC 8446 4.4.1: it resets
+// it to SHA3-256(firstClientHello) followed by the HelloRetryRequest frame. The
+// caller has already accumulated only ClientHello1 in the transcript.
+func (h *Handshake) replaceFirstHelloWithHash(hrrFrame []byte) error {
+	ch1Hash, err := crypto.TranscriptHash(h.firstClientHello)
+	if err != nil {
+		return err
+	}
+	h.transcript.Reset()
+	h.transcript.Write(ch1Hash)
+	h.transcript.Write(hrrFrame)
+	return nil
 }
 
 // ProcessServerHello processes the ServerHello message (initiator).
@@ -373,12 +452,24 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 		return qerrors.ErrUnsupportedVersion
 	}
 
-	// Negotiate the KEM suite: adopt the suite the client's key share uses. With only
-	// CH-KEM-v1 registered this always resolves; an unsupported suite fails closed for
-	// now (HelloRetryRequest steers the client to a mutual suite in a later change).
+	// Negotiate the KEM suite before any heavy crypto. If we do not support the suite
+	// the client's key share uses, steer it with a HelloRetryRequest to a mutually
+	// supported suite (once). If there is no overlap, or we already retried, fail closed.
 	suite, err := resolveKEMSuite(msg.KEMSuite)
 	if err != nil {
-		return err
+		if h.hrrDone {
+			return err
+		}
+		mutual, ok := selectMutualKEMSuite(msg.KEMSuites)
+		if !ok {
+			return qerrors.ErrUnsupportedKEMSuite
+		}
+		// Short-circuit: do not process this hello's key share. Remember it for the
+		// synthetic transcript hash and signal the driver to send a HelloRetryRequest.
+		h.firstClientHello = data
+		h.hrrSuite = mutual
+		h.sendHRR = true
+		return nil
 	}
 	h.session.kemSuite = suite
 
@@ -446,6 +537,30 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 	h.session.SetState(SessionStateHandshaking)
 
 	return nil
+}
+
+// CreateHelloRetryRequest builds the HelloRetryRequest the driver sends instead of
+// ServerHello when ProcessClientHello signaled a KEM-suite mismatch. It applies the
+// RFC 8446 4.4.1 synthetic transcript (hash of ClientHello1 + this HRR), so the
+// retried exchange stays downgrade-bound. Valid only right after ProcessClientHello
+// set sendHRR.
+func (h *Handshake) CreateHelloRetryRequest() ([]byte, error) {
+	if !h.sendHRR {
+		return nil, qerrors.ErrInvalidState
+	}
+	data, err := h.codec.EncodeHelloRetryRequest(&protocol.HelloRetryRequest{
+		Version:  protocol.Current,
+		KEMSuite: uint16(h.hrrSuite),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := h.replaceFirstHelloWithHash(data); err != nil {
+		return nil, err
+	}
+	h.sendHRR = false
+	h.hrrDone = true
+	return data, nil
 }
 
 // CreateServerHello generates the ServerHello message.
@@ -690,14 +805,39 @@ func supportedKEMSuiteIDs() []uint16 {
 }
 
 // resolveKEMSuite returns the registered suite for a wire id, or an error if this
-// peer does not support it. The HelloRetryRequest path (a later change) will let a
-// server steer an unsupported initiator to a mutual suite instead of failing.
+// peer does not support it.
 func resolveKEMSuite(wireID uint16) (chkem.Suite, error) {
 	suite, ok := chkem.GetSuite(chkem.SuiteID(wireID))
 	if !ok {
 		return nil, qerrors.ErrUnsupportedKEMSuite
 	}
 	return suite, nil
+}
+
+// offeredKEMSuite reports whether wireID is one of the suites this peer supports
+// (and therefore would have advertised), so a HelloRetryRequest cannot steer the
+// client to a suite it never offered.
+func offeredKEMSuite(wireID uint16) bool {
+	for _, id := range chkem.SupportedSuites() {
+		if uint16(id) == wireID {
+			return true
+		}
+	}
+	return false
+}
+
+// selectMutualKEMSuite picks the locally-supported suite (in this peer's preference
+// order) that also appears in the client's advertised list, or false if there is no
+// overlap. The server uses it to steer an unsupported client via HelloRetryRequest.
+func selectMutualKEMSuite(clientSuites []uint16) (chkem.SuiteID, bool) {
+	for _, local := range chkem.SupportedSuites() {
+		for _, offered := range clientSuites {
+			if uint16(local) == offered {
+				return local, true
+			}
+		}
+	}
+	return 0, false
 }
 
 // cleanup zeroizes sensitive handshake data.
@@ -768,6 +908,84 @@ func readEncryptedRecord(r io.Reader) ([]byte, error) {
 // --- High-Level API ---
 
 // InitiatorHandshake performs the complete handshake as initiator.
+// initiatorExchangeHellos sends the ClientHello, handles an optional
+// HelloRetryRequest (one retry, resending the ClientHello in the server's suite),
+// and processes the ServerHello. Shared by the fresh and resumption initiator drivers.
+func initiatorExchangeHellos(h *Handshake, rw io.ReadWriter) error {
+	clientHello, err := h.CreateClientHello()
+	if err != nil {
+		return err
+	}
+	if _, err := rw.Write(clientHello); err != nil {
+		return err
+	}
+
+	msg, err := h.codec.ReadMessage(rw)
+	if err != nil {
+		return err
+	}
+	if protocol.MessageType(msg[0]) == protocol.MessageTypeHelloRetryRequest {
+		if err := h.ProcessHelloRetryRequest(msg); err != nil {
+			sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+			return err
+		}
+		retry, err := h.CreateClientHello()
+		if err != nil {
+			return err
+		}
+		if _, err := rw.Write(retry); err != nil {
+			return err
+		}
+		if msg, err = h.codec.ReadMessage(rw); err != nil {
+			return err
+		}
+	}
+
+	if err := h.ProcessServerHello(msg); err != nil {
+		sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+		return err
+	}
+	return nil
+}
+
+// responderExchangeHellos reads the ClientHello, sends a HelloRetryRequest if the
+// client's KEM suite is unsupported (one retry), processes the resulting ClientHello,
+// and sends the ServerHello. Shared by the fresh and resumption responder drivers.
+func responderExchangeHellos(h *Handshake, rw io.ReadWriter) error {
+	clientHello, err := h.codec.ReadMessage(rw)
+	if err != nil {
+		return err
+	}
+	if err := h.ProcessClientHello(clientHello); err != nil {
+		sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+		return err
+	}
+	if h.sendHRR {
+		hrr, err := h.CreateHelloRetryRequest()
+		if err != nil {
+			return err
+		}
+		if _, err := rw.Write(hrr); err != nil {
+			return err
+		}
+		retry, err := h.codec.ReadMessage(rw)
+		if err != nil {
+			return err
+		}
+		if err := h.ProcessClientHello(retry); err != nil {
+			sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+			return err
+		}
+	}
+
+	serverHello, err := h.CreateServerHello()
+	if err != nil {
+		return err
+	}
+	_, err = rw.Write(serverHello)
+	return err
+}
+
 func InitiatorHandshake(session *Session, rw io.ReadWriter) error {
 	observer := session.observer
 	var done func(error)
@@ -778,22 +996,8 @@ func InitiatorHandshake(session *Session, rw io.ReadWriter) error {
 	err := func() error {
 		h := NewHandshake(session)
 
-		// Send ClientHello
-		clientHello, err := h.CreateClientHello()
-		if err != nil {
-			return err
-		}
-		if _, err := rw.Write(clientHello); err != nil {
-			return err
-		}
-
-		// Receive ServerHello
-		serverHello, err := h.codec.ReadMessage(rw)
-		if err != nil {
-			return err
-		}
-		if err := h.ProcessServerHello(serverHello); err != nil {
-			sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+		// Exchange hellos (with an optional HelloRetryRequest) and process ServerHello.
+		if err := initiatorExchangeHellos(h, rw); err != nil {
 			return err
 		}
 
@@ -858,22 +1062,8 @@ func ResponderHandshake(session *Session, rw io.ReadWriter) error {
 	err := func() error {
 		h := NewHandshake(session)
 
-		// Receive ClientHello
-		clientHello, err := h.codec.ReadMessage(rw)
-		if err != nil {
-			return err
-		}
-		if err := h.ProcessClientHello(clientHello); err != nil {
-			sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
-			return err
-		}
-
-		// Send ServerHello
-		serverHello, err := h.CreateServerHello()
-		if err != nil {
-			return err
-		}
-		if _, err := rw.Write(serverHello); err != nil {
+		// Receive ClientHello (with an optional HelloRetryRequest) and send ServerHello.
+		if err := responderExchangeHellos(h, rw); err != nil {
 			return err
 		}
 
@@ -924,22 +1114,8 @@ func InitiatorResumptionHandshake(session *Session, rw io.ReadWriter, ticket, se
 		h := NewHandshake(session)
 		h.SetTicket(ticket, secret)
 
-		// Send ClientHello
-		clientHello, err := h.CreateClientHello()
-		if err != nil {
-			return err
-		}
-		if _, err := rw.Write(clientHello); err != nil {
-			return err
-		}
-
-		// Receive ServerHello
-		serverHello, err := h.codec.ReadMessage(rw)
-		if err != nil {
-			return err
-		}
-		if err := h.ProcessServerHello(serverHello); err != nil {
-			sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
+		// Exchange hellos (with an optional HelloRetryRequest) and process ServerHello.
+		if err := initiatorExchangeHellos(h, rw); err != nil {
 			return err
 		}
 
@@ -998,22 +1174,8 @@ func ResponderResumptionHandshake(session *Session, rw io.ReadWriter, tm *Ticket
 	h := NewHandshake(session)
 	h.SetTicketManager(tm)
 
-	// Receive ClientHello
-	clientHello, err := h.codec.ReadMessage(rw)
-	if err != nil {
-		return err
-	}
-	if err := h.ProcessClientHello(clientHello); err != nil {
-		sendHandshakeAlert(rw, h.codec, protocol.AlertCodeHandshakeFailure, "handshake failed")
-		return err
-	}
-
-	// Send ServerHello
-	serverHello, err := h.CreateServerHello()
-	if err != nil {
-		return err
-	}
-	if _, err := rw.Write(serverHello); err != nil {
+	// Receive ClientHello (with an optional HelloRetryRequest) and send ServerHello.
+	if err := responderExchangeHellos(h, rw); err != nil {
 		return err
 	}
 

--- a/pkg/tunnel/hrr_test.go
+++ b/pkg/tunnel/hrr_test.go
@@ -1,0 +1,164 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/pkg/chkem"
+)
+
+// stubSuite wraps CH-KEM-v1 but reports an unregistered suite id, so a server
+// (which only has v1 in its registry) cannot resolve it and must HelloRetryRequest
+// the client down to v1. All crypto delegates to v1.
+type stubSuite struct {
+	chkem.Suite
+}
+
+const stubSuiteID chkem.SuiteID = 0x9999
+
+func (stubSuite) ID() chkem.SuiteID { return stubSuiteID }
+
+func newStubLedInitiator(t *testing.T) *Session {
+	t.Helper()
+	s, err := NewSession(RoleInitiator)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	stub := stubSuite{Suite: chkem.DefaultSuite()}
+	kp, err := stub.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("stub GenerateKeyPair: %v", err)
+	}
+	s.LocalKeyPair.Zeroize()
+	s.kemSuite = stub
+	s.LocalKeyPair = kp
+	return s
+}
+
+// TestHelloRetryRequestStream drives a stream handshake where the client leads with
+// a suite the server does not support; the server HelloRetryRequests down to v1 and
+// the handshake completes on v1.
+func TestHelloRetryRequestStream(t *testing.T) {
+	initiator := newStubLedInitiator(t)
+	responder, err := NewSession(RoleResponder)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = serverConn.Close() }()
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- InitiatorHandshake(initiator, clientConn) }()
+	go func() { errCh <- ResponderHandshake(responder, serverConn) }()
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("handshake: %v", err)
+		}
+	}
+
+	if initiator.kemSuite.ID() != chkem.SuiteCHKEMv1 || responder.kemSuite.ID() != chkem.SuiteCHKEMv1 {
+		t.Errorf("after HRR: initiator=%#x responder=%#x, want CH-KEM-v1",
+			initiator.kemSuite.ID(), responder.kemSuite.ID())
+	}
+	if initiator.State() != SessionStateEstablished || responder.State() != SessionStateEstablished {
+		t.Errorf("not established: initiator=%v responder=%v", initiator.State(), responder.State())
+	}
+}
+
+// driveHRR runs the HRR exchange through the handshake methods directly (no network),
+// optionally mutating the first ClientHello bytes the server sees. It returns the
+// error from ProcessClientFinished, which fails if the two transcripts diverge.
+func driveHRR(t *testing.T, mutateCH1 func([]byte)) error {
+	t.Helper()
+	client := NewHandshake(newStubLedInitiator(t))
+	server := NewHandshake(mustResponder(t))
+
+	ch1, err := client.CreateClientHello()
+	if err != nil {
+		t.Fatalf("CreateClientHello: %v", err)
+	}
+	seen := append([]byte(nil), ch1...)
+	if mutateCH1 != nil {
+		mutateCH1(seen)
+	}
+	if err := server.ProcessClientHello(seen); err != nil {
+		t.Fatalf("server ProcessClientHello(ch1): %v", err)
+	}
+	if !server.sendHRR {
+		t.Fatal("server did not signal HelloRetryRequest for the unsupported suite")
+	}
+	hrr, err := server.CreateHelloRetryRequest()
+	if err != nil {
+		t.Fatalf("CreateHelloRetryRequest: %v", err)
+	}
+	if err := client.ProcessHelloRetryRequest(hrr); err != nil {
+		t.Fatalf("client ProcessHelloRetryRequest: %v", err)
+	}
+	ch2, err := client.CreateClientHello()
+	if err != nil {
+		t.Fatalf("CreateClientHello(retry): %v", err)
+	}
+	if err := server.ProcessClientHello(ch2); err != nil {
+		t.Fatalf("server ProcessClientHello(ch2): %v", err)
+	}
+	sh, err := server.CreateServerHello()
+	if err != nil {
+		t.Fatalf("CreateServerHello: %v", err)
+	}
+	if err := client.ProcessServerHello(sh); err != nil {
+		t.Fatalf("client ProcessServerHello: %v", err)
+	}
+	cf, err := client.CreateClientFinished()
+	if err != nil {
+		t.Fatalf("CreateClientFinished: %v", err)
+	}
+	return server.ProcessClientFinished(cf)
+}
+
+func mustResponder(t *testing.T) *Session {
+	t.Helper()
+	s, err := NewSession(RoleResponder)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	return s
+}
+
+// TestHRRUntamperedCompletes is the control: an unmodified HRR exchange verifies.
+func TestHRRUntamperedCompletes(t *testing.T) {
+	if err := driveHRR(t, nil); err != nil {
+		t.Fatalf("untampered HRR ClientFinished failed: %v", err)
+	}
+}
+
+// TestHRRClientHello1TamperBreaksFinished proves the synthetic message hash binds
+// ClientHello1: changing any byte of the first hello the server sees diverges the
+// transcripts so the ClientFinished MAC fails (a downgrade attempt is detected).
+func TestHRRClientHello1TamperBreaksFinished(t *testing.T) {
+	// Flip a byte inside ClientHello1's random (offset 7: header(5)+version(2)).
+	err := driveHRR(t, func(ch1 []byte) { ch1[10] ^= 0xFF })
+	if err == nil {
+		t.Fatal("tampered ClientHello1 still produced a valid ClientFinished (synthetic hash not binding)")
+	}
+}
+
+// TestHRRSecondUnsupportedHelloRejected bounds the retry: after one HelloRetryRequest
+// the server rejects a second unsupported ClientHello rather than looping.
+func TestHRRSecondUnsupportedHelloRejected(t *testing.T) {
+	client := NewHandshake(newStubLedInitiator(t))
+	server := NewHandshake(mustResponder(t))
+
+	ch1, _ := client.CreateClientHello()
+	if err := server.ProcessClientHello(ch1); err != nil {
+		t.Fatalf("ProcessClientHello(ch1): %v", err)
+	}
+	if _, err := server.CreateHelloRetryRequest(); err != nil {
+		t.Fatalf("CreateHelloRetryRequest: %v", err)
+	}
+	// A misbehaving client re-sends the same unsupported suite; the server must fail.
+	if err := server.ProcessClientHello(ch1); err == nil {
+		t.Fatal("server accepted a second unsupported ClientHello after a HelloRetryRequest")
+	}
+}


### PR DESCRIPTION
Stream half: HelloRetryRequest on the TCP/stream handshake. The security-critical core of KEM-suite agility.

## Behavior
When a server lacks the KEM suite a client's key share used, it answers `HelloRetryRequest` naming a mutual suite (from the client's advertised list, server preference order) instead of failing. The client adopts the suite, regenerates its share, and resends one ClientHello. Both peers cap at a single retry.

- `ProcessClientHello` resolves the suite **before any heavy crypto** and short-circuits on a mismatch (commits no key state) - cheap, DoS-safe.
- On retry the client keeps `clientRandom`/`SessionID`/supported-list stable; only the suite + key share change (TLS 1.3 behavior).
- The four stream drivers (fresh + resumption, both roles) share two new `*ExchangeHellos` helpers, so all of them get HRR.

## Downgrade safety (RFC 8446 4.4.1)
The transcript is rewritten to `SHA3-256(ClientHello1) || HelloRetryRequest` before ClientHello2 is appended, binding the original advertisement across the retry. `TestHRRClientHello1TamperBreaksFinished` flips a byte in the first hello the server sees and asserts the ClientFinished MAC fails - this is the exact spot TLS 1.3 had downgrade CVEs.

## Tests
- `TestHelloRetryRequestStream`: client leads with a white-box stub suite the server lacks; the handshake HRRs down to v1 and completes (both established on v1).
- `TestHRRUntamperedCompletes` / `TestHRRClientHello1TamperBreaksFinished`: control + downgrade detection.
- `TestHRRSecondUnsupportedHelloRejected`: bounded retry.

Only CH-KEM-v1 registers, so HRR never triggers in production yet (no behavior change for real handshakes). The datagram FSM wiring is the next change; X-Wing (the first real second suite) follows later on, according to the roadmap.

Full `go test ./... -race`, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 clean; demo verified (normal v1 path unchanged).
