### PR TITLE
wire HelloRetryRequest into the datagram handshake FSM

### DIFF
--- a/pkg/tunnel/dgram_handshake_fsm.go
+++ b/pkg/tunnel/dgram_handshake_fsm.go
@@ -11,7 +11,11 @@
 // (datagram.go). Each transition produces exactly one handshake message.
 package tunnel
 
-import "github.com/sara-star-quant/quantum-go/pkg/protocol"
+import (
+	"bytes"
+
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
 
 // hsMessage is one serialized handshake message plus its type. The bytes are the
 // verbatim output of a flight builder (a plaintext codec frame for the Hellos, or
@@ -76,6 +80,12 @@ func (d *dgramHandshake) onMessage(typ protocol.MessageType, body []byte) (out *
 	switch {
 	case typ != 0 && typ == d.expecting:
 		return d.advance(typ, body)
+	case d.role == RoleInitiator && typ == protocol.MessageTypeHelloRetryRequest &&
+		d.expecting == protocol.MessageTypeServerHello && !d.hs.hrrDone:
+		// First HelloRetryRequest while awaiting ServerHello: adopt the suite and
+		// re-send the ClientHello. A duplicate HRR (hrrDone) falls through to the
+		// retransmit case below and replays the cached retried ClientHello.
+		return d.advance(typ, body)
 	case typ != 0 && typ == d.prev && d.cached != nil:
 		return d.cached, false // retransmit: replay last flight, no re-invocation
 	default:
@@ -108,9 +118,37 @@ func (d *dgramHandshake) advance(typ protocol.MessageType, body []byte) (out *hs
 		d.expecting = 0 // no further inbound
 		return nil, true
 
+	case d.role == RoleInitiator && typ == protocol.MessageTypeHelloRetryRequest:
+		if err := d.hs.ProcessHelloRetryRequest(body); err != nil {
+			return nil, false
+		}
+		reply, err := d.hs.CreateClientHello() // retried hello in the server's suite
+		if err != nil {
+			return nil, false
+		}
+		d.commit(typ, &hsMessage{typ: protocol.MessageTypeClientHello, body: reply}, protocol.MessageTypeServerHello)
+		return d.cached, false
+
 	case d.role == RoleResponder && typ == protocol.MessageTypeClientHello:
+		// After we have sent a HelloRetryRequest, a repeat of the pre-HRR ClientHello
+		// is a retransmit of a lost HRR: replay the cached HRR rather than reprocess
+		// (the retransmit and the genuine retried hello share the ClientHello type, so
+		// distinguish them by content).
+		if d.hs.hrrDone && d.cached != nil && d.cached.typ == protocol.MessageTypeHelloRetryRequest &&
+			bytes.Equal(body, d.hs.firstClientHello) {
+			return d.cached, false
+		}
 		if err := d.hs.ProcessClientHello(body); err != nil {
 			return nil, false
+		}
+		if d.hs.sendHRR {
+			hrr, err := d.hs.CreateHelloRetryRequest()
+			if err != nil {
+				return nil, false
+			}
+			// Stay expecting a ClientHello (the client's retried hello in our suite).
+			d.commit(typ, &hsMessage{typ: protocol.MessageTypeHelloRetryRequest, body: hrr}, protocol.MessageTypeClientHello)
+			return d.cached, false
 		}
 		reply, err := d.hs.CreateServerHello()
 		if err != nil {

--- a/pkg/tunnel/dgram_hrr_test.go
+++ b/pkg/tunnel/dgram_hrr_test.go
@@ -1,0 +1,76 @@
+package tunnel
+
+import (
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/pkg/chkem"
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// fsmStep passes one message into an FSM and returns its reply.
+func fsmStep(t *testing.T, d *dgramHandshake, m *hsMessage) (*hsMessage, bool) {
+	t.Helper()
+	if m == nil {
+		t.Fatal("nil message fed to FSM")
+	}
+	return d.onMessage(m.typ, m.body)
+}
+
+// TestDatagramHRR drives the datagram handshake FSM through a HelloRetryRequest:
+// the initiator leads with an unsupported (stub) suite, the responder steers it to
+// CH-KEM-v1, and the handshake completes on v1.
+func TestDatagramHRR(t *testing.T) {
+	clientSess := newStubLedInitiator(t)
+	serverSess := mustResponder(t)
+	client := newDgramHandshake(clientSess)
+	server := newDgramHandshake(serverSess)
+
+	ch1, err := client.start()
+	if err != nil {
+		t.Fatalf("client start: %v", err)
+	}
+
+	hrr, _ := fsmStep(t, server, ch1)
+	if hrr == nil || hrr.typ != protocol.MessageTypeHelloRetryRequest {
+		t.Fatalf("responder did not emit HelloRetryRequest, got %+v", hrr)
+	}
+
+	// A lost HRR: the initiator retransmits ClientHello1; the responder must replay
+	// the cached HRR (not reprocess), recovering from the loss.
+	replay, _ := fsmStep(t, server, ch1)
+	if replay == nil || replay.typ != protocol.MessageTypeHelloRetryRequest {
+		t.Fatalf("responder did not replay HRR on a retransmitted ClientHello1, got %+v", replay)
+	}
+
+	ch2, _ := fsmStep(t, client, hrr)
+	if ch2 == nil || ch2.typ != protocol.MessageTypeClientHello {
+		t.Fatalf("initiator did not emit a retried ClientHello, got %+v", ch2)
+	}
+
+	sh, _ := fsmStep(t, server, ch2)
+	if sh == nil || sh.typ != protocol.MessageTypeServerHello {
+		t.Fatalf("responder did not emit ServerHello after the retry, got %+v", sh)
+	}
+
+	cf, _ := fsmStep(t, client, sh)
+	if cf == nil || cf.typ != protocol.MessageTypeClientFinished {
+		t.Fatalf("initiator did not emit ClientFinished, got %+v", cf)
+	}
+
+	sf, serverDone := fsmStep(t, server, cf)
+	if sf == nil || sf.typ != protocol.MessageTypeServerFinished || !serverDone {
+		t.Fatalf("responder did not complete with ServerFinished, got %+v done=%v", sf, serverDone)
+	}
+
+	if _, clientDone := fsmStep(t, client, sf); !clientDone {
+		t.Fatal("initiator did not complete on ServerFinished")
+	}
+
+	if clientSess.kemSuite.ID() != chkem.SuiteCHKEMv1 || serverSess.kemSuite.ID() != chkem.SuiteCHKEMv1 {
+		t.Errorf("after datagram HRR: client=%#x server=%#x, want CH-KEM-v1",
+			clientSess.kemSuite.ID(), serverSess.kemSuite.ID())
+	}
+	if !client.isComplete() || !server.isComplete() {
+		t.Error("FSMs did not both report complete")
+	}
+}


### PR DESCRIPTION
Datagram half: HelloRetryRequest on the UDP/datagram handshake, completing feature.

## What
The datagram FSM (`dgram_handshake_fsm.go`) now drives the same HRR exchange as the stream path, reusing the `Handshake` HRR builders:
- Responder on a suite mismatch: cache a HelloRetryRequest, stay expecting a ClientHello.
- Initiator while awaiting ServerHello: adopt the server's suite, re-create the ClientHello, continue. Capped at one retry.

## The retransmit subtlety
A retransmitted ClientHello1 and the genuine retried ClientHello2 share the `ClientHello` type, so the responder distinguishes them by **content** (compares to the cached first hello). A lost HRR therefore replays the cached HRR rather than reprocessing - the test covers this.

The cookie return-routability gate runs before the FSM and stays orthogonal; the responder commits no key state for the HRR, so its anti-amplification posture is unchanged.

## Tests
`TestDatagramHRR` drives the FSM through the full retry with a stub suite, exercises the lost-HRR replay, and asserts completion on v1. Only CH-KEM-v1 registers, so HRR never triggers in production yet (existing datagram tests untouched).

Full `go test ./... -race`, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 clean.