### PR TITLE
add an X-Wing KEM crypto wrapper

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -169,6 +169,21 @@ const (
 	CHKEMSharedSecretSize = 32
 )
 
+// X-Wing KEM sizes (standardized ML-KEM-768 + X25519 combiner, draft-connolly-cfrg-xwing-kem).
+const (
+	// XWingPublicKeySize is the X-Wing public key length: ML-KEM-768 (1184) + X25519 (32).
+	XWingPublicKeySize = 1216
+
+	// XWingCiphertextSize is the X-Wing ciphertext length: ML-KEM-768 ct (1088) + X25519 (32).
+	XWingCiphertextSize = 1120
+
+	// XWingSeedSize is the X-Wing private key / derivation seed length.
+	XWingSeedSize = 32
+
+	// XWingSharedSecretSize is the X-Wing shared secret length.
+	XWingSharedSecretSize = 32
+)
+
 // Datagram (UDP) Transport Parameters
 //
 // These govern the connectionless datagram transport, which has its own wire

--- a/pkg/crypto/xwing.go
+++ b/pkg/crypto/xwing.go
@@ -1,0 +1,109 @@
+// Package crypto - xwing.go wraps the standardized X-Wing KEM (ML-KEM-768 + X25519
+// with a fixed SHA3-256 combiner) from draft-connolly-cfrg-xwing-kem. It delegates
+// to cloudflare/circl's certified implementation, so the wire output is byte-exact
+// with any other X-Wing implementation; this package never re-implements the
+// combiner. The private key is the 32-byte derivation seed (circl PrivateKeySize).
+package crypto
+
+import (
+	"github.com/cloudflare/circl/kem/xwing"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
+)
+
+// XWingKeyPair is an X-Wing key pair: the 32-byte private seed and the 1216-byte
+// packed public key.
+type XWingKeyPair struct {
+	privateSeed []byte
+	publicKey   []byte
+}
+
+// GenerateXWingKeyPair generates a fresh X-Wing key pair from system randomness.
+func GenerateXWingKeyPair() (*XWingKeyPair, error) {
+	seed := make([]byte, xwing.SeedSize)
+	if err := SecureRandom(seed); err != nil {
+		return nil, qerrors.NewCryptoError("XWing.Generate", err)
+	}
+	return NewXWingKeyPairFromSeed(seed)
+}
+
+// NewXWingKeyPairFromSeed deterministically derives an X-Wing key pair from a
+// 32-byte seed. The same seed always yields the same key pair and public pin.
+func NewXWingKeyPairFromSeed(seed []byte) (*XWingKeyPair, error) {
+	if len(seed) != xwing.SeedSize {
+		return nil, qerrors.ErrInvalidKeySize
+	}
+	sk, pk := xwing.DeriveKeyPairPacked(seed)
+	return &XWingKeyPair{privateSeed: sk, publicKey: pk}, nil
+}
+
+// PublicKeyBytes returns the packed public key.
+func (kp *XWingKeyPair) PublicKeyBytes() []byte {
+	out := make([]byte, len(kp.publicKey))
+	copy(out, kp.publicKey)
+	return out
+}
+
+// SeedBytes returns the 32-byte private seed (the X-Wing private key).
+func (kp *XWingKeyPair) SeedBytes() []byte {
+	out := make([]byte, len(kp.privateSeed))
+	copy(out, kp.privateSeed)
+	return out
+}
+
+// Zeroize erases the private seed.
+func (kp *XWingKeyPair) Zeroize() {
+	Zeroize(kp.privateSeed)
+	kp.privateSeed = nil
+	kp.publicKey = nil
+}
+
+// XWingEncapsulate encapsulates to a packed X-Wing public key, returning the
+// ciphertext and the 32-byte shared secret. It samples its own encapsulation
+// randomness.
+func XWingEncapsulate(publicKey []byte) (ciphertext, sharedSecret []byte, err error) {
+	if len(publicKey) != constants.XWingPublicKeySize {
+		return nil, nil, qerrors.ErrInvalidPublicKey
+	}
+	seed := make([]byte, xwing.EncapsulationSeedSize)
+	if err := SecureRandom(seed); err != nil {
+		return nil, nil, qerrors.NewCryptoError("XWing.Encapsulate", err)
+	}
+	return xwingEncapsulateWithSeed(publicKey, seed)
+}
+
+// xwingEncapsulateWithSeed is the seed-injected core of XWingEncapsulate, used by
+// the conformance test to reproduce the published X-Wing vectors.
+func xwingEncapsulateWithSeed(publicKey, seed []byte) (ciphertext, sharedSecret []byte, err error) {
+	if len(seed) != xwing.EncapsulationSeedSize {
+		return nil, nil, qerrors.ErrInvalidKeySize
+	}
+	ss, ct, err := xwing.Encapsulate(publicKey, seed)
+	if err != nil {
+		return nil, nil, qerrors.NewCryptoError("XWing.Encapsulate", err)
+	}
+	return ct, ss, nil
+}
+
+// XWingDecapsulate recovers the 32-byte shared secret from a ciphertext using the
+// 32-byte private seed.
+func XWingDecapsulate(privateSeed, ciphertext []byte) ([]byte, error) {
+	if len(privateSeed) != constants.XWingSeedSize {
+		return nil, qerrors.ErrInvalidPrivateKey
+	}
+	if len(ciphertext) != constants.XWingCiphertextSize {
+		return nil, qerrors.ErrInvalidCiphertext
+	}
+	return xwing.Decapsulate(ciphertext, privateSeed), nil
+}
+
+// ParseXWingPublicKey validates and copies a packed X-Wing public key.
+func ParseXWingPublicKey(data []byte) ([]byte, error) {
+	if len(data) != constants.XWingPublicKeySize {
+		return nil, qerrors.ErrInvalidPublicKey
+	}
+	out := make([]byte, len(data))
+	copy(out, data)
+	return out, nil
+}

--- a/pkg/crypto/xwing_test.go
+++ b/pkg/crypto/xwing_test.go
@@ -1,0 +1,125 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cloudflare/circl/kem/xwing"
+)
+
+// writeHexX mirrors circl's xwing test-vector formatter byte-for-byte so the digest
+// below matches the published X-Wing spec vectors.
+func writeHexX(w io.Writer, prefix string, val []byte) {
+	indent := "  "
+	width := 74
+	hex := fmt.Sprintf("%x", val)
+	if len(prefix)+len(hex)+5 < width {
+		_, _ = fmt.Fprintf(w, "%s     %s\n", prefix, hex)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s\n", prefix)
+	for len(hex) != 0 {
+		var toPrint string
+		if len(hex) < width-len(indent) {
+			toPrint = hex
+			hex = ""
+		} else {
+			toPrint = hex[:width-len(indent)]
+			hex = hex[width-len(indent):]
+		}
+		_, _ = fmt.Fprintf(w, "%s%s\n", indent, toPrint)
+	}
+}
+
+// TestXWingConformanceVectors drives the published X-Wing test vectors through this
+// wrapper and checks the SHAKE-128 digest of the formatted output against the value
+// from the X-Wing spec (draft-connolly-cfrg-xwing-kem). It also cross-checks each
+// derived key against circl directly, so the wrapper is a faithful passthrough.
+func TestXWingConformanceVectors(t *testing.T) {
+	h := sha3.NewSHAKE128()
+	w := new(bytes.Buffer)
+
+	for range 3 {
+		var seed [xwing.SeedSize]byte
+		_, _ = h.Read(seed[:])
+		writeHexX(w, "seed", seed[:])
+
+		kp, err := NewXWingKeyPairFromSeed(seed[:])
+		if err != nil {
+			t.Fatalf("NewXWingKeyPairFromSeed: %v", err)
+		}
+		sk := kp.SeedBytes()
+		pk := kp.PublicKeyBytes()
+
+		// The wrapper must derive byte-identically to circl.
+		csk, cpk := xwing.DeriveKeyPairPacked(seed[:])
+		if !bytes.Equal(sk, csk) || !bytes.Equal(pk, cpk) {
+			t.Fatal("wrapper key derivation diverges from circl")
+		}
+		writeHexX(w, "sk", sk)
+		writeHexX(w, "pk", pk)
+
+		var eseed [xwing.EncapsulationSeedSize]byte
+		_, _ = h.Read(eseed[:])
+		writeHexX(w, "eseed", eseed[:])
+
+		ct, ss, err := xwingEncapsulateWithSeed(pk, eseed[:])
+		if err != nil {
+			t.Fatalf("encapsulate: %v", err)
+		}
+		writeHexX(w, "ct", ct)
+		writeHexX(w, "ss", ss)
+
+		ss2, err := XWingDecapsulate(sk, ct)
+		if err != nil {
+			t.Fatalf("decapsulate: %v", err)
+		}
+		if !bytes.Equal(ss, ss2) {
+			t.Fatal("decapsulated secret does not match encapsulated secret")
+		}
+		_, _ = fmt.Fprintf(w, "\n")
+	}
+
+	h2 := sha3.NewSHAKE128()
+	_, _ = h2.Write(w.Bytes())
+	var cs [32]byte
+	_, _ = h2.Read(cs[:])
+	got := fmt.Sprintf("%x", cs)
+	const want = "1bcd0057d861d6b866239936cadcaeee1ec0164dedc181c386e9e54fe46156fe"
+	if got != want {
+		t.Fatalf("X-Wing conformance digest mismatch:\n got %s\nwant %s", got, want)
+	}
+}
+
+// TestXWingRoundTrip checks a generated key pair encapsulates and decapsulates to a
+// matching 32-byte secret, and that wrong sizes are rejected.
+func TestXWingRoundTrip(t *testing.T) {
+	kp, err := GenerateXWingKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateXWingKeyPair: %v", err)
+	}
+	ct, ss, err := XWingEncapsulate(kp.PublicKeyBytes())
+	if err != nil {
+		t.Fatalf("XWingEncapsulate: %v", err)
+	}
+	if len(ss) != 32 {
+		t.Errorf("shared secret length = %d, want 32", len(ss))
+	}
+	ss2, err := XWingDecapsulate(kp.SeedBytes(), ct)
+	if err != nil {
+		t.Fatalf("XWingDecapsulate: %v", err)
+	}
+	if !bytes.Equal(ss, ss2) {
+		t.Error("round-trip shared secret mismatch")
+	}
+
+	if _, _, err := XWingEncapsulate(make([]byte, 10)); err == nil {
+		t.Error("expected error for a wrong-size public key")
+	}
+	if _, err := XWingDecapsulate(kp.SeedBytes(), make([]byte, 10)); err == nil {
+		t.Error("expected error for a wrong-size ciphertext")
+	}
+}


### PR DESCRIPTION
The X-Wing KEM primitive, self-contained and additive.

## What
`pkg/crypto/xwing.go` wraps the standardized X-Wing KEM (ML-KEM-768 + X25519, fixed SHA3-256 combiner; draft-connolly-cfrg-xwing-kem) by delegating to cloudflare/circl's certified implementation - **byte-exact interop, no hand-rolled combiner**. Private key = 32-byte seed; public key 1216 B, ciphertext 1120 B (both smaller than CH-KEM-v1's 1600, so they fit the datagram frag cap). Generate / derive-from-seed / encapsulate / decapsulate over packed bytes, mirroring `mlkem.go`, with size guards so malformed input returns an error instead of panicking inside circl.

## Conformance
`TestXWingConformanceVectors` drives the **published X-Wing spec vectors** through the wrapper and checks the SHAKE-128 digest of the formatted output against the spec value (`1bcd0057...`), and cross-checks each derived key against circl directly. Plus a generate/encap/decap round-trip and size-rejection test.

Additive only - nothing registers X-Wing in the KEM-suite registry yet (the suite + container dispatch + keygen follow). No behavior change.

`go test ./... `, `go vet`, `gofmt`, `golangci-lint`, gosec @v2.22.11 clean.