### PR TITLE
register X-Wing as a negotiable KEM suite

### DIFF
--- a/pkg/chkem/chkem.go
+++ b/pkg/chkem/chkem.go
@@ -107,7 +107,10 @@ func protocolVersionBytes() []byte {
 	return b
 }
 
-// KeyPair represents a CH-KEM key pair combining X25519 and ML-KEM-1024.
+// KeyPair represents a KEM key pair. For CH-KEM-v1 it holds the X25519 and
+// ML-KEM-1024 components directly. For other suites (suite != 0) the typed v1
+// fields stay nil and impl carries the suite's live key handle; the generic methods
+// dispatch on suite.
 type KeyPair struct {
 	// X25519 key pair (classical)
 	x25519Public  *ecdh.PublicKey
@@ -116,21 +119,34 @@ type KeyPair struct {
 	// ML-KEM-1024 key pair (post-quantum)
 	mlkemPublic  *crypto.MLKEMPublicKey
 	mlkemPrivate *crypto.MLKEMPrivateKey
+
+	// suite is zero for CH-KEM-v1 and the suite id otherwise; impl is the non-v1
+	// suite's live key handle.
+	suite SuiteID
+	impl  any
 }
 
-// PublicKey represents a CH-KEM public key for encapsulation.
+// PublicKey represents a KEM public key for encapsulation. For non-v1 suites raw
+// holds the serialized key and the typed fields stay nil.
 type PublicKey struct {
 	x25519 *ecdh.PublicKey
 	mlkem  *crypto.MLKEMPublicKey
+
+	suite SuiteID
+	raw   []byte
 }
 
-// Ciphertext represents a CH-KEM ciphertext.
+// Ciphertext represents a KEM ciphertext. For non-v1 suites raw holds the
+// serialized ciphertext and the typed fields stay nil.
 type Ciphertext struct {
 	// X25519 ephemeral public key (32 bytes)
 	x25519Ephemeral []byte
 
 	// ML-KEM-1024 ciphertext (1568 bytes)
 	mlkemCiphertext []byte
+
+	suite SuiteID
+	raw   []byte
 }
 
 // GenerateKeyPair generates a new CH-KEM key pair.
@@ -209,8 +225,21 @@ func ParseKeyPair(seed []byte) (*KeyPair, error) {
 	}, nil
 }
 
+// suiteKeyHandle is the live private-key handle a non-v1 suite stores in
+// KeyPair.impl. The crypto wrappers (e.g. *crypto.XWingKeyPair) satisfy it.
+type suiteKeyHandle interface {
+	PublicKeyBytes() []byte
+	Zeroize()
+}
+
 // PublicKey returns the public component of the key pair.
 func (kp *KeyPair) PublicKey() *PublicKey {
+	if kp.suite != 0 {
+		if h, ok := kp.impl.(suiteKeyHandle); ok {
+			return &PublicKey{suite: kp.suite, raw: h.PublicKeyBytes()}
+		}
+		return &PublicKey{suite: kp.suite}
+	}
 	return &PublicKey{
 		x25519: kp.x25519Public,
 		mlkem:  kp.mlkemPublic,
@@ -363,6 +392,9 @@ func Decapsulate(ct *Ciphertext, kp *KeyPair, role Role) ([]byte, error) {
 // Format: x25519_public (32 bytes) || mlkem_public (1568 bytes)
 // Total: 1600 bytes
 func (pk *PublicKey) Bytes() []byte {
+	if pk.suite != 0 {
+		return cloneBytes(pk.raw)
+	}
 	result := make([]byte, constants.CHKEMPublicKeySize)
 	copy(result[:constants.X25519PublicKeySize], pk.x25519.Bytes())
 	copy(result[constants.X25519PublicKeySize:], pk.mlkem.Bytes())
@@ -396,10 +428,20 @@ func ParsePublicKey(data []byte) (*PublicKey, error) {
 // Format: x25519_ephemeral (32 bytes) || mlkem_ciphertext (1568 bytes)
 // Total: 1600 bytes
 func (ct *Ciphertext) Bytes() []byte {
+	if ct.suite != 0 {
+		return cloneBytes(ct.raw)
+	}
 	result := make([]byte, constants.CHKEMCiphertextSize)
 	copy(result[:constants.X25519PublicKeySize], ct.x25519Ephemeral)
 	copy(result[constants.X25519PublicKeySize:], ct.mlkemCiphertext)
 	return result
+}
+
+// cloneBytes returns an independent copy of b.
+func cloneBytes(b []byte) []byte {
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
 }
 
 // ParseCiphertext parses a CH-KEM ciphertext from bytes.
@@ -416,6 +458,13 @@ func ParseCiphertext(data []byte) (*Ciphertext, error) {
 
 // Zeroize securely erases the private key material.
 func (kp *KeyPair) Zeroize() {
+	if kp.suite != 0 {
+		if h, ok := kp.impl.(suiteKeyHandle); ok {
+			h.Zeroize()
+		}
+		kp.impl = nil
+		return
+	}
 	kp.x25519Private = nil
 	kp.x25519Public = nil
 	kp.mlkemPrivate = nil
@@ -424,6 +473,9 @@ func (kp *KeyPair) Zeroize() {
 
 // Clone creates a deep copy of the public key.
 func (pk *PublicKey) Clone() *PublicKey {
+	if pk.suite != 0 {
+		return &PublicKey{suite: pk.suite, raw: cloneBytes(pk.raw)}
+	}
 	return &PublicKey{
 		x25519: pk.x25519,
 		mlkem:  pk.mlkem,

--- a/pkg/chkem/suite.go
+++ b/pkg/chkem/suite.go
@@ -85,6 +85,7 @@ func (chkemV1) IsFIPSApproved() bool { return true }
 // registry maps a SuiteID to its implementation.
 var registry = map[SuiteID]Suite{
 	SuiteCHKEMv1: chkemV1{},
+	SuiteXWing:   xwingSuite{},
 }
 
 // DefaultSuite returns the default KEM suite (CH-KEM-v1). It is the suite used when
@@ -101,5 +102,5 @@ func GetSuite(id SuiteID) (Suite, bool) {
 // preferred first). CH-KEM-v1 is always present as the mandatory default, so any
 // two peers share it.
 func SupportedSuites() []SuiteID {
-	return []SuiteID{SuiteCHKEMv1}
+	return []SuiteID{SuiteCHKEMv1, SuiteXWing}
 }

--- a/pkg/chkem/suite_xwing.go
+++ b/pkg/chkem/suite_xwing.go
@@ -1,0 +1,99 @@
+package chkem
+
+import (
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+	qerrors "github.com/sara-star-quant/quantum-go/internal/errors"
+	"github.com/sara-star-quant/quantum-go/pkg/crypto"
+)
+
+// SuiteXWing is the standardized X-Wing KEM (ML-KEM-768 + X25519 with a fixed
+// SHA3-256 combiner, draft-connolly-cfrg-xwing-kem). It is the interop-friendly
+// alternative to CH-KEM-v1: smaller key share, byte-exact with any X-Wing peer.
+const SuiteXWing SuiteID = 0x0002
+
+// xwingSuite adapts the X-Wing crypto wrapper to the Suite interface. It stores the
+// live key handle in KeyPair.impl and the serialized public key/ciphertext in the
+// raw field of PublicKey/Ciphertext.
+type xwingSuite struct{}
+
+func (xwingSuite) ID() SuiteID { return SuiteXWing }
+
+func (xwingSuite) GenerateKeyPair() (*KeyPair, error) {
+	kp, err := crypto.GenerateXWingKeyPair()
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPair{suite: SuiteXWing, impl: kp}, nil
+}
+
+func (xwingSuite) GenerateStaticKeyPair() (*KeyPair, []byte, error) {
+	seed, err := crypto.SecureRandomBytes(constants.XWingSeedSize)
+	if err != nil {
+		return nil, nil, qerrors.NewCryptoError("XWing.GenerateStaticKeyPair", err)
+	}
+	kp, err := crypto.NewXWingKeyPairFromSeed(seed)
+	if err != nil {
+		crypto.Zeroize(seed)
+		return nil, nil, err
+	}
+	return &KeyPair{suite: SuiteXWing, impl: kp}, seed, nil
+}
+
+func (xwingSuite) ParseKeyPair(seed []byte) (*KeyPair, error) {
+	kp, err := crypto.NewXWingKeyPairFromSeed(seed)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyPair{suite: SuiteXWing, impl: kp}, nil
+}
+
+// Encapsulate ignores role: X-Wing's combiner is spec-fixed, so it cannot bind the
+// role the way CH-KEM-v1 does. Role, version, and suite downgrade protection come
+// from the handshake transcript / Finished MAC instead.
+func (xwingSuite) Encapsulate(recipient *PublicKey, _ Role) (*Ciphertext, []byte, error) {
+	if recipient == nil || recipient.suite != SuiteXWing {
+		return nil, nil, qerrors.ErrInvalidPublicKey
+	}
+	ct, ss, err := crypto.XWingEncapsulate(recipient.raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &Ciphertext{suite: SuiteXWing, raw: ct}, ss, nil
+}
+
+func (xwingSuite) Decapsulate(ct *Ciphertext, kp *KeyPair, _ Role) ([]byte, error) {
+	if ct == nil || ct.suite != SuiteXWing {
+		return nil, qerrors.ErrInvalidCiphertext
+	}
+	xkp, ok := kp.impl.(*crypto.XWingKeyPair)
+	if !ok {
+		return nil, qerrors.ErrInvalidPrivateKey
+	}
+	return crypto.XWingDecapsulate(xkp.SeedBytes(), ct.raw)
+}
+
+func (xwingSuite) ParsePublicKey(data []byte) (*PublicKey, error) {
+	raw, err := crypto.ParseXWingPublicKey(data)
+	if err != nil {
+		return nil, err
+	}
+	return &PublicKey{suite: SuiteXWing, raw: raw}, nil
+}
+
+func (xwingSuite) ParseCiphertext(data []byte) (*Ciphertext, error) {
+	if len(data) != constants.XWingCiphertextSize {
+		return nil, qerrors.ErrInvalidCiphertext
+	}
+	return &Ciphertext{suite: SuiteXWing, raw: cloneBytes(data)}, nil
+}
+
+func (xwingSuite) PublicKeySize() int { return constants.XWingPublicKeySize }
+
+func (xwingSuite) CiphertextSize() int { return constants.XWingCiphertextSize }
+
+func (xwingSuite) SeedSize() int { return constants.XWingSeedSize }
+
+// IsFIPSApproved follows v1's operational posture: the hybrid uses X25519, so this
+// is not a strict FIPS 140-3 algorithm claim. X-Wing is NIST Category 3 (ML-KEM-768)
+// versus v1's Category 5 (ML-KEM-1024); both stay allowed in the FIPS build.
+func (xwingSuite) IsFIPSApproved() bool { return true }

--- a/pkg/chkem/suite_xwing_test.go
+++ b/pkg/chkem/suite_xwing_test.go
@@ -1,0 +1,84 @@
+package chkem
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/internal/constants"
+)
+
+// TestXWingSuiteRoundTrip exercises the X-Wing suite through the Suite interface:
+// generate, serialize/parse the public key and ciphertext, and encapsulate then
+// decapsulate to a matching 32-byte secret.
+func TestXWingSuiteRoundTrip(t *testing.T) {
+	s, ok := GetSuite(SuiteXWing)
+	if !ok {
+		t.Fatal("X-Wing suite is not registered")
+	}
+	if s.PublicKeySize() != constants.XWingPublicKeySize ||
+		s.CiphertextSize() != constants.XWingCiphertextSize ||
+		s.SeedSize() != constants.XWingSeedSize {
+		t.Fatalf("unexpected sizes: pub=%d ct=%d seed=%d", s.PublicKeySize(), s.CiphertextSize(), s.SeedSize())
+	}
+
+	kp, err := s.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	pubBytes := kp.PublicKey().Bytes()
+	if len(pubBytes) != constants.XWingPublicKeySize {
+		t.Fatalf("public key length = %d, want %d", len(pubBytes), constants.XWingPublicKeySize)
+	}
+
+	pub, err := s.ParsePublicKey(pubBytes)
+	if err != nil {
+		t.Fatalf("ParsePublicKey: %v", err)
+	}
+	ct, ss, err := s.Encapsulate(pub, RoleResponder)
+	if err != nil {
+		t.Fatalf("Encapsulate: %v", err)
+	}
+	if len(ss) != constants.CHKEMSharedSecretSize {
+		t.Fatalf("shared secret length = %d, want %d", len(ss), constants.CHKEMSharedSecretSize)
+	}
+
+	ct2, err := s.ParseCiphertext(ct.Bytes())
+	if err != nil {
+		t.Fatalf("ParseCiphertext: %v", err)
+	}
+	ss2, err := s.Decapsulate(ct2, kp, RoleInitiator)
+	if err != nil {
+		t.Fatalf("Decapsulate: %v", err)
+	}
+	if !bytes.Equal(ss, ss2) {
+		t.Fatal("decapsulated secret does not match")
+	}
+}
+
+// TestXWingStaticKeyPairDeterministic confirms a static X-Wing identity round-trips
+// from its seed to the same public pin.
+func TestXWingStaticKeyPairDeterministic(t *testing.T) {
+	s, _ := GetSuite(SuiteXWing)
+	kp, seed, err := s.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateStaticKeyPair: %v", err)
+	}
+	if len(seed) != constants.XWingSeedSize {
+		t.Fatalf("seed length = %d, want %d", len(seed), constants.XWingSeedSize)
+	}
+	kp2, err := s.ParseKeyPair(seed)
+	if err != nil {
+		t.Fatalf("ParseKeyPair: %v", err)
+	}
+	if !bytes.Equal(kp.PublicKey().Bytes(), kp2.PublicKey().Bytes()) {
+		t.Fatal("static key pair did not reconstruct the same public pin from its seed")
+	}
+}
+
+// TestSupportedSuitesIncludesXWing confirms the registry advertises X-Wing after v1.
+func TestSupportedSuitesIncludesXWing(t *testing.T) {
+	ids := SupportedSuites()
+	if len(ids) < 2 || ids[0] != SuiteCHKEMv1 || ids[1] != SuiteXWing {
+		t.Fatalf("SupportedSuites = %v, want [CH-KEM-v1, X-Wing]", ids)
+	}
+}

--- a/pkg/tunnel/xwing_test.go
+++ b/pkg/tunnel/xwing_test.go
@@ -1,0 +1,92 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+
+	"github.com/sara-star-quant/quantum-go/pkg/chkem"
+	"github.com/sara-star-quant/quantum-go/pkg/protocol"
+)
+
+// newXWingInitiator returns an initiator session whose key share uses the X-Wing
+// suite, so a handshake against a default responder negotiates X-Wing end to end.
+func newXWingInitiator(t *testing.T) *Session {
+	t.Helper()
+	s, err := NewSession(RoleInitiator)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	suite, ok := chkem.GetSuite(chkem.SuiteXWing)
+	if !ok {
+		t.Fatal("X-Wing suite is not registered")
+	}
+	kp, err := suite.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("X-Wing GenerateKeyPair: %v", err)
+	}
+	s.LocalKeyPair.Zeroize()
+	s.kemSuite = suite
+	s.LocalKeyPair = kp
+	return s
+}
+
+// TestXWingHandshakeStream runs a full stream handshake where the client leads with
+// X-Wing; the responder adopts it (both peers support it) and the handshake
+// completes on X-Wing with no HelloRetryRequest.
+func TestXWingHandshakeStream(t *testing.T) {
+	initiator := newXWingInitiator(t)
+	responder, err := NewSession(RoleResponder)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+	defer func() { _ = serverConn.Close() }()
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- InitiatorHandshake(initiator, clientConn) }()
+	go func() { errCh <- ResponderHandshake(responder, serverConn) }()
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("handshake: %v", err)
+		}
+	}
+
+	if initiator.kemSuite.ID() != chkem.SuiteXWing || responder.kemSuite.ID() != chkem.SuiteXWing {
+		t.Errorf("negotiated suites: initiator=%#x responder=%#x, want X-Wing",
+			initiator.kemSuite.ID(), responder.kemSuite.ID())
+	}
+	if initiator.State() != SessionStateEstablished || responder.State() != SessionStateEstablished {
+		t.Errorf("not established: initiator=%v responder=%v", initiator.State(), responder.State())
+	}
+}
+
+// TestXWingHandshakeDatagram drives the datagram FSM through an X-Wing handshake.
+func TestXWingHandshakeDatagram(t *testing.T) {
+	client := newDgramHandshake(newXWingInitiator(t))
+	server := newDgramHandshake(mustResponder(t))
+
+	ch, err := client.start()
+	if err != nil {
+		t.Fatalf("client start: %v", err)
+	}
+	sh, _ := fsmStep(t, server, ch)
+	if sh == nil || sh.typ != protocol.MessageTypeServerHello {
+		t.Fatalf("responder did not emit ServerHello, got %+v", sh)
+	}
+	cf, _ := fsmStep(t, client, sh)
+	if cf == nil || cf.typ != protocol.MessageTypeClientFinished {
+		t.Fatalf("initiator did not emit ClientFinished, got %+v", cf)
+	}
+	sf, serverDone := fsmStep(t, server, cf)
+	if sf == nil || sf.typ != protocol.MessageTypeServerFinished || !serverDone {
+		t.Fatalf("responder did not complete, got %+v done=%v", sf, serverDone)
+	}
+	if _, clientDone := fsmStep(t, client, sf); !clientDone {
+		t.Fatal("initiator did not complete")
+	}
+	if client.hs.session.kemSuite.ID() != chkem.SuiteXWing || server.hs.session.kemSuite.ID() != chkem.SuiteXWing {
+		t.Error("datagram handshake did not negotiate X-Wing")
+	}
+}


### PR DESCRIPTION
Make X-Wing a real, negotiable KEM suite.

## What
- `SuiteXWing` (0x0002) added to the registry and to `SupportedSuites` (after CH-KEM-v1). `suite_xwing.go` wraps the X-Wing crypto primitive behind the `Suite` interface.
- **Suite-agnostic containers**: `KeyPair`/`PublicKey`/`Ciphertext` gain a suite discriminator. CH-KEM-v1 values leave it at zero and keep the typed X25519/ML-KEM fields, so the **v1 path stays byte-identical**; a non-v1 suite stores its live handle in `impl` and serialized form in `raw`. The generic methods (`Bytes`/`PublicKey`/`Zeroize`/`Clone`) dispatch on the discriminator. The v1 component accessors stay v1-internal (confirmed no external callers).
- X-Wing's combiner is spec-fixed, so its Encapsulate/Decapsulate ignore `role`; role/version/downgrade protection come from the handshake transcript + Finished MAC (not the KEM). `IsFIPSApproved` matches v1's operational posture; X-Wing is NIST Cat 3 vs v1 Cat 5.

## Behavior
A client that leads with X-Wing negotiates it end to end on both transports (the responder adopts the client's suite). The **default client still leads with CH-KEM-v1**, so existing handshakes are unchanged - the demo still runs v1.

## Tests
- chkem: suite round-trip through the interface, static-identity seed round-trip, `SupportedSuites` order.
- tunnel: full X-Wing handshake on stream + datagram (both end on X-Wing, established).

Full `go test ./... -race`, `go vet`, `gofmt`, module-wide `golangci-lint`, gosec @v2.22.11 clean; demo verified (v1 default unchanged). keygen `--suite` + suite-tagged identities follow in the last slice.