### PR TITLE
dispatch static-key authentication on the pinned key's suite

### DIFF
--- a/pkg/chkem/chkem.go
+++ b/pkg/chkem/chkem.go
@@ -482,6 +482,24 @@ func (pk *PublicKey) Clone() *PublicKey {
 	}
 }
 
+// Suite returns the KEM suite this public key belongs to. A CH-KEM-v1 key (the
+// zero discriminator) reports SuiteCHKEMv1.
+func (pk *PublicKey) Suite() SuiteID {
+	if pk.suite == 0 {
+		return SuiteCHKEMv1
+	}
+	return pk.suite
+}
+
+// Suite returns the KEM suite this key pair belongs to (SuiteCHKEMv1 for the zero
+// discriminator).
+func (kp *KeyPair) Suite() SuiteID {
+	if kp.suite == 0 {
+		return SuiteCHKEMv1
+	}
+	return kp.suite
+}
+
 // X25519PublicKey returns the X25519 component of the public key.
 func (pk *PublicKey) X25519PublicKey() *ecdh.PublicKey {
 	return pk.x25519

--- a/pkg/tunnel/handshake.go
+++ b/pkg/tunnel/handshake.go
@@ -177,9 +177,15 @@ func (h *Handshake) CreateClientHello() ([]byte, error) {
 	}
 
 	// Static-key authentication: encapsulate to the pinned server static key so
-	// only the holder of the matching private key can derive the same secret.
+	// only the holder of the matching private key can derive the same secret. The
+	// static leg uses the pinned key's own suite, which is independent of the
+	// negotiated ephemeral suite.
 	if h.session.PinnedServerKey != nil {
-		staticCT, staticSecret, err := h.session.kemSuite.Encapsulate(h.session.PinnedServerKey, chkem.RoleInitiator)
+		staticSuite, err := resolveKEMSuite(uint16(h.session.PinnedServerKey.Suite()))
+		if err != nil {
+			return nil, err
+		}
+		staticCT, staticSecret, err := staticSuite.Encapsulate(h.session.PinnedServerKey, chkem.RoleInitiator)
 		if err != nil {
 			return nil, err
 		}
@@ -505,11 +511,17 @@ func (h *Handshake) ProcessClientHello(data []byte) error {
 	// rejection means a wrong key yields a pseudo-random secret (no error/oracle);
 	// the mismatch surfaces later as a Finished MAC failure.
 	if h.session.StaticKeyPair != nil && len(msg.CHKEMStaticCiphertext) > 0 {
-		staticCT, err := h.session.kemSuite.ParseCiphertext(msg.CHKEMStaticCiphertext)
+		// The static leg uses our static identity's own suite, independent of the
+		// negotiated ephemeral suite.
+		staticSuite, err := resolveKEMSuite(uint16(h.session.StaticKeyPair.Suite()))
 		if err != nil {
 			return err
 		}
-		staticSecret, err := h.session.kemSuite.Decapsulate(staticCT, h.session.StaticKeyPair, chkem.RoleResponder)
+		staticCT, err := staticSuite.ParseCiphertext(msg.CHKEMStaticCiphertext)
+		if err != nil {
+			return err
+		}
+		staticSecret, err := staticSuite.Decapsulate(staticCT, h.session.StaticKeyPair, chkem.RoleResponder)
 		if err != nil {
 			return err
 		}

--- a/pkg/tunnel/static_auth_test.go
+++ b/pkg/tunnel/static_auth_test.go
@@ -202,3 +202,33 @@ func TestStaticAuthRequiredMisconfiguredRejected(t *testing.T) {
 		t.Fatalf("misconfigured require-auth: got %v, want ErrStaticAuthMisconfigured", acceptErr)
 	}
 }
+
+// TestStaticAuthXWingPin authenticates with an X-Wing static identity while the
+// ephemeral key exchange stays on the default CH-KEM-v1 suite, exercising the
+// static leg's dispatch on the pinned key's own suite.
+func TestStaticAuthXWingPin(t *testing.T) {
+	suite, ok := chkem.GetSuite(chkem.SuiteXWing)
+	if !ok {
+		t.Fatal("X-Wing suite is not registered")
+	}
+	serverKP, _, err := suite.GenerateStaticKeyPair()
+	if err != nil {
+		t.Fatalf("X-Wing GenerateStaticKeyPair: %v", err)
+	}
+	if serverKP.Suite() != chkem.SuiteXWing {
+		t.Fatalf("static key suite = %#x, want X-Wing", serverKP.Suite())
+	}
+
+	serverCfg := tunnel.DefaultTransportConfig()
+	serverCfg.StaticKeyPair = serverKP
+	clientCfg := tunnel.DefaultTransportConfig()
+	clientCfg.PinnedServerKey = serverKP.PublicKey()
+
+	clientErr, accepted := runStaticAuthHandshake(t, serverCfg, clientCfg)
+	if clientErr != nil {
+		t.Fatalf("X-Wing-pinned handshake failed: %v", clientErr)
+	}
+	if !accepted {
+		t.Error("server did not accept the X-Wing-authenticated session")
+	}
+}


### PR DESCRIPTION
Make X-Wing usable for static-key endpoint authentication.

## Problem
The static-key auth leg encapsulated to the pinned server key (and decapsulated the static ciphertext) using the **negotiated ephemeral suite**. But a pinned identity's suite is independent of the ephemeral key exchange, so an X-Wing pin used with a v1 ephemeral handshake failed (`v1.Encapsulate` on an X-Wing key -> `ErrInvalidPublicKey`).

## Fix
Resolve the static leg's suite from the pinned key (client) or static key pair (responder) via a new `KeyPair`/`PublicKey` `Suite()` accessor, and run the static encap / ciphertext parse / decap through that suite. The ephemeral legs still use the negotiated suite.

A v1 pin reports `SuiteCHKEMv1`, so existing static-key handshakes stay byte-identical. `TestStaticAuthXWingPin` authenticates with an X-Wing pin while the ephemeral exchange stays on v1.

Full `go test ./... -race`, `go vet`, `gofmt`, module-wide `golangci-lint`, gosec @v2.22.11 clean. keygen `--suite` (to mint X-Wing identities from the CLI) is the final slice.