### PR TITLE
harden the X-Wing decapsulate against a nil key pair and zeroize the seed copy

### DIFF
--- a/pkg/chkem/suite_xwing.go
+++ b/pkg/chkem/suite_xwing.go
@@ -65,11 +65,16 @@ func (xwingSuite) Decapsulate(ct *Ciphertext, kp *KeyPair, _ Role) ([]byte, erro
 	if ct == nil || ct.suite != SuiteXWing {
 		return nil, qerrors.ErrInvalidCiphertext
 	}
+	if kp == nil {
+		return nil, qerrors.ErrInvalidPrivateKey
+	}
 	xkp, ok := kp.impl.(*crypto.XWingKeyPair)
 	if !ok {
 		return nil, qerrors.ErrInvalidPrivateKey
 	}
-	return crypto.XWingDecapsulate(xkp.SeedBytes(), ct.raw)
+	seed := xkp.SeedBytes()
+	defer crypto.Zeroize(seed)
+	return crypto.XWingDecapsulate(seed, ct.raw)
 }
 
 func (xwingSuite) ParsePublicKey(data []byte) (*PublicKey, error) {


### PR DESCRIPTION
Two Low/Nit robustness fixes surfaced by the KEM-suite agility review (both reviewers APPROVE'd; neither is wire-reachable today).

- `xwingSuite.Decapsulate` now guards `kp == nil` before the `kp.impl` type assertion, matching the CH-KEM-v1 `Decapsulate` - a nil key pair returns `ErrInvalidPrivateKey` instead of panicking.
- It zeroizes the seed copy `SeedBytes()` returns once decapsulation completes, so the 32-byte private seed does not linger on the heap until GC.

Defense in depth: all current callers pass a locally-owned non-nil key pair, so neither path is reachable from the wire. `go test ./... `, gofmt, golangci-lint clean.