### PR TITLE
prepare the v0.0.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+## [0.0.15][] - 2026-06-20
+
+**Theme:** Crypto-agility and X-Wing. The hardcoded CH-KEM becomes a negotiated, pluggable KEM suite, and the standardized X-Wing KEM (ML-KEM-768 + X25519) lands as a second, interop-friendly suite. Peers negotiate the suite on the wire with a HelloRetryRequest fallback and a downgrade-safe synthetic-hash transcript, and the wire length-prefixes the now suite-sized KEM material (protocol 5.0). The default handshake stays on CH-KEM-v1 and is byte-identical, so the change is opt-in.
+
 ### Added
 - **KEM-suite abstraction (foundation for crypto-agility)**: `pkg/chkem` now exposes a `Suite` interface, a `SuiteID` wire identifier, and a registry, with the existing CH-KEM (ML-KEM-1024 + X25519 + SHAKE-256) registered as `SuiteCHKEMv1` (the default). The v1 suite delegates to the existing functions, so output is byte-for-byte unchanged; this is the additive first step toward negotiated, pluggable KEMs (X-Wing interop, HQC diversification). No wire or behavior change yet.
 - **HelloRetryRequest for KEM-suite negotiation**: when a server does not support the KEM suite a client's key share used, it now replies with a HelloRetryRequest naming a mutually-supported suite and the client retries once, on both the stream and datagram transports, instead of failing the handshake. The retry rewrites the handshake transcript with the RFC 8446 4.4.1 synthetic message hash, so tampering with the first ClientHello breaks the Finished MAC (downgrade-safe).
@@ -347,7 +351,8 @@ Benchmark results (Apple Silicon M1 Pro, Go 1.26):
 - Basic tunnel API
 - Unit tests for crypto primitives
 
-[Unreleased]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.14...HEAD
+[Unreleased]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.15...HEAD
+[0.0.15]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/sara-star-quant/quantum-go/compare/v0.0.11...v0.0.12

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,13 +5,14 @@
 
 ---
 
-## Current Status: v0.0.14
+## Current Status: v0.0.15
 
-> **Direction.** Endpoint authentication (static-key pinning, require-auth, PSK mutual auth),
-> role binding, CI security, the 1024-bit stream replay window, and the session-bound derived
-> stream nonce have landed. The remaining **stream security parity** item is resumption ticket
-> server binding. After that, **crypto-agility** toward v0.1.0 (HQC code-based KEM diversification
-> for a CH-KEM v2 triple cascade).
+> **Direction.** Crypto-agility has landed: the KEM is now a negotiated, pluggable suite with a
+> HelloRetryRequest fallback, and X-Wing (ML-KEM-768 + X25519) ships as a second interop-friendly
+> suite (protocol 5.0). Earlier work (endpoint authentication, role binding, CI security, the
+> 1024-bit stream replay window, the session-bound derived stream nonce) is in. The remaining
+> **stream security parity** item is resumption ticket server binding. Next toward v0.1.0: HQC
+> code-based KEM diversification for a CH-KEM v2 triple cascade.
 
 ## Strategic Priorities (valuation-driven)
 


### PR DESCRIPTION
Promote the crypto-agility and X-Wing work from Unreleased to **v0.0.15**.

Theme: the hardcoded CH-KEM becomes a negotiated, pluggable KEM suite, and X-Wing (ML-KEM-768 + X25519) ships as a second interop-friendly suite. Negotiation with a HelloRetryRequest fallback and a downgrade-safe synthetic-hash transcript; length-prefixed suite-sized KEM material (protocol 5.0). Default handshake stays CH-KEM-v1, byte-identical.