### PR TITLE
add machine-checked ProVerif proofs of the CH-KEM handshake

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,0 +1,44 @@
+name: Formal Verification
+
+# Path-filtered: this runs ONLY when the formal models change, so a minutes-long
+# ProVerif proof never gates ordinary code or doc commits.
+on:
+  push:
+    paths:
+      - 'docs/formal/**'
+      - '.github/workflows/formal.yml'
+  pull_request:
+    paths:
+      - 'docs/formal/**'
+      - '.github/workflows/formal.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  proverif:
+    name: ProVerif symbolic proofs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      # Buildx with the docker-container driver is required for the gha build cache.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the pinned ProVerif image
+        uses: docker/build-push-action@v6
+        with:
+          context: docs/formal
+          file: docs/formal/proverif.Dockerfile
+          tags: qgo-proverif
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify models (positives prove, negatives fail)
+        run: docs/formal/verify.sh
+
+      - name: Assert the committed proof log is up to date
+        run: git diff --exit-code docs/formal/RESULTS.txt

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ See [Quick Start Guide](docs/usage/QUICKSTART.md) for detailed examples.
 | [CLI Reference](docs/usage/CLI.md) | Using `quantum-tunnel` for demos and benchmarks |
 | [Architecture](docs/technical/ARCHITECTURE.md) | CH-KEM protocol and security design |
 | [Protocol Specification](docs/PROTOCOL.md) | Wire handshake, KEM negotiation, and key schedule (interop profile) |
+| [Formal Verification](docs/formal/README.md) | Machine-checked ProVerif proofs (secrecy, hybrid, forward secrecy, server auth) |
 | [Threat Model](docs/technical/THREAT_MODEL.md) | Self-authored threat and risk analysis (NIST SP 800-30) |
 | [Roadmap](docs/ROADMAP.md) | Development roadmap and compliance plans |
 

--- a/docs/DESIGN_INFLUENCES.md
+++ b/docs/DESIGN_INFLUENCES.md
@@ -58,9 +58,9 @@ The protocol draws on the shared knowledge base of post-quantum cryptography res
 
 **Concept:** Post-quantum hybrid protocols should be formally verified to ensure that the composition of classical and post-quantum primitives does not introduce subtle vulnerabilities absent in either component alone.
 
-**Our adaptation:** ProVerif/Tamarin model of the CH-KEM 4-message handshake (planned for v0.1.0 audit preparation).
+**Our adaptation (delivered):** a ProVerif symbolic model of the CH-KEM handshake machine-checks session-key secrecy, the hybrid "secure if either leg holds" guarantee, forward secrecy, and injective server authentication, with planted-flaw negative tests for non-vacuity. See [docs/formal/](formal/README.md). This is symbolic (Dolev-Yao) verification of the protocol composition; it complements the computational IND-CCA argument in [math/MATHEMATICAL_FOUNDATION.md](math/MATHEMATICAL_FOUNDATION.md).
 
-**Difference:** Lafourcade's analysis targets WireGuard's Noise IK pattern with bolt-on PQ KEM. Our model will cover CH-KEM's TLS 1.3-structured handshake, which has a fundamentally different message flow (4-message with explicit Finished messages vs. Noise IK's 2-message pattern).
+**Difference:** Lafourcade's analysis targets WireGuard's Noise IK pattern with bolt-on PQ KEM. Our model covers CH-KEM's TLS 1.3-structured handshake, which has a fundamentally different message flow (explicit Finished messages vs. Noise IK's 2-message pattern).
 
 ### 2.6 KEM-Based Handshake Optimization
 

--- a/docs/formal/README.md
+++ b/docs/formal/README.md
@@ -1,0 +1,87 @@
+# Formal verification of the CH-KEM handshake
+
+Machine-checked symbolic (Dolev-Yao) proofs of the Quantum-Go handshake's core security
+properties, using [ProVerif](https://bblanche.gitlabpages.inria.fr/proverif/) 2.05. The
+committed proof log is [`RESULTS.txt`](RESULTS.txt).
+
+## What is proven
+
+| Property | Model | ProVerif query | Result |
+| -------- | ----- | -------------- | ------ |
+| Session-key secrecy | `chkem_secrecy.pv` | `attacker(secretMsg)` unreachable | proven |
+| Hybrid security (secure if EITHER leg holds) | `chkem_hybrid.pv` | secrecy holds when the attacker is given one leg's secret, both legs | proven |
+| Forward secrecy | `chkem_fs.pv` | secrecy holds after the long-term key leaks (phase 1) | proven |
+| Server authentication (injective) + transcript agreement | `chkem_auth.pv` | `inj-event(ClientAccept) ==> inj-event(ServerRunning)` | proven |
+
+The hybrid result machine-checks the headline guarantee: the session key stays secret as long
+as the structured-lattice (ML-KEM) OR the classical (X25519) leg holds. Server authentication
+gives agreement on the full transcript, which is the symbolic Finished-binding / anti-downgrade
+property.
+
+## Adversary model
+
+The active Dolev-Yao attacker controls the entire network (intercept, modify, drop, inject,
+replay, reorder), runs unbounded concurrent sessions, and applies every public operation. The
+hybrid and forward-secrecy models additionally hand the attacker a compromised secret (one leg's
+key; the long-term static key). A query asks whether ANY attacker strategy violates the property,
+over all sessions - an exhaustive symbolic search, not a single trace.
+
+## Non-vacuity (the proofs have teeth)
+
+Two safeguards, both enforced by `verify.sh`:
+
+- **Reachability.** Each model proves an honest run completes (an `event` is reachable), so a
+  secrecy result is not vacuously true on a dead protocol.
+- **Negative tests.** `negative/` holds a planted-flaw twin of each model (the combiner forgets a
+  secret; the Finished is not key-bound). Each MUST fail its query. A suite that cannot detect a
+  planted flaw is not assurance; these show it does.
+
+## Scope and model fidelity (read this before citing the proofs)
+
+This is SYMBOLIC verification under the perfect-cryptography assumption. It checks the PROTOCOL
+COMPOSITION - secrecy, the hybrid combiner, authentication, forward secrecy, transcript binding -
+and catches protocol-logic flaws (man-in-the-middle, replay, downgrade, authentication bypass,
+mis-binding). It does NOT cover computational or probabilistic attacks, side channels, or weak
+randomness; those are the computational IND-CCA argument in
+[`../math/MATHEMATICAL_FOUNDATION.md`](../math/MATHEMATICAL_FOUNDATION.md) and the planned audit.
+
+Symbolic verification proves the protocol DESIGN, not the Go implementation. The model primitives
+map to the code as follows, and the byte-level behavior of those functions is pinned by the
+committed conformance vectors (`../../testdata/conformance/`):
+
+| Model primitive | Code realization |
+| --------------- | ---------------- |
+| KEM `aenc`/`adec` | `pkg/chkem` over `pkg/crypto/{mlkem,x25519,xwing}.go` |
+| combiner `deriveMaster` / `authMaster` | `crypto.DeriveCHKEMSecret`, `crypto.DeriveAuthenticatedSecret` (`pkg/crypto/kdf.go`) |
+| Finished MAC `macf` | the verify_data KDF (`pkg/tunnel/handshake.go`) |
+| transcript `TH` | `crypto.TranscriptHash` (`pkg/crypto/kdf.go`) |
+
+Design-proven (ProVerif) plus implementation-pinned (conformance vectors) is the honest claim.
+Closing the gap fully would need code-level verification, which is out of scope.
+
+## Reproducing
+
+```
+docker build -t qgo-proverif -f docs/formal/proverif.Dockerfile docs/formal/
+docs/formal/verify.sh
+```
+
+`verify.sh` runs every model through the pinned ProVerif image, requires every positive query to
+prove and every negative query to fail, and regenerates `RESULTS.txt`. CI runs the same script,
+path-filtered to `docs/formal/**` so it does not gate ordinary commits.
+
+## Keeping the model in sync
+
+The models track `pkg/chkem`, `pkg/tunnel/handshake.go`, and `pkg/crypto/kdf.go`. A change to the
+handshake or KEM construction in those files requires reviewing and, if needed, updating these
+models - the path-filtered CI will not catch protocol drift on its own.
+
+## Coverage map
+
+Proven now: session-key secrecy, hybrid security, forward secrecy, injective server authentication
+(static-key-pinned mode), for protocol version 5.0.
+
+Planned (extends the suite as drop-in `*.pv` files): PSK mutual-authentication mode; an explicit
+HelloRetryRequest / suite-negotiation process modeling downgrade as a distinct query; the
+rekey-ratchet forward secrecy; per-suite models (X-Wing, a future CH-KEM-v2); and a computational
+proof (CryptoVerif/EasyCrypt).

--- a/docs/formal/RESULTS.txt
+++ b/docs/formal/RESULTS.txt
@@ -1,0 +1,34 @@
+Quantum-Go formal verification results
+Tool: Proverif 2.05. Cryptographic protocol verifier, by Bruno Blanchet, Vincent Cheval, and Marc Sylvestre
+Protocol version verified: 5.0
+
+=== chkem_auth.pv ===
+RESULT inj-event(ClientAccept(sp,t)) ==> inj-event(ServerRunning(sp,t)) is true.
+RESULT not event(AuthDone) is false.
+
+=== chkem_fs.pv ===
+RESULT not attacker_p1(secretMsg[]) is true.
+RESULT not event(Done) is false.
+
+=== chkem_hybrid.pv ===
+RESULT not attacker(secretMsgA[]) is true.
+RESULT not attacker(secretMsgB[]) is true.
+RESULT not event(DoneH) is false.
+
+=== chkem_secrecy.pv ===
+RESULT not attacker(secretMsg[]) is true.
+RESULT not event(Done) is false.
+
+=== negative/auth_broken.pv ===
+RESULT inj-event(ClientAccept(sp,t)) ==> inj-event(ServerRunning(sp,t)) is false.
+RESULT (even event(ClientAccept(sp,t)) ==> event(ServerRunning(sp,t)) is false.)
+
+=== negative/fs_broken.pv ===
+RESULT not attacker_p1(secretMsg[]) is false.
+
+=== negative/hybrid_broken.pv ===
+RESULT not attacker(secretMsgA[]) is false.
+
+=== negative/secrecy_broken.pv ===
+RESULT not attacker(secretMsg[]) is false.
+

--- a/docs/formal/chkem_auth.pv
+++ b/docs/formal/chkem_auth.pv
@@ -1,0 +1,48 @@
+(*
+  CH-KEM server authentication (symbolic). Load: -lib prelude.
+
+  Static-key-pinned mode: the client encapsulates a secret to the server's pinned
+  long-term key; only the holder of that key (lsk) can decapsulate it and derive the
+  master, so only the real server can produce a ServerFinished MAC the client accepts.
+  The active Dolev-Yao attacker may inject/modify any message but, lacking lsk, cannot
+  forge the MAC. Proves agreement: a client acceptance with server sp and transcript t
+  implies the genuine server sp ran on t (hence agreement on the transcript - the
+  symbolic Finished-binding / anti-downgrade property).
+*)
+
+event ServerRunning(pkey, bitstring).
+event ClientAccept(pkey, bitstring).
+
+query sp: pkey, t: bitstring;
+  inj-event(ClientAccept(sp, t)) ==> inj-event(ServerRunning(sp, t)).
+
+event AuthDone.
+query event(AuthDone).
+
+let clientA(Spub: pkey) =
+  new staticSs: bitstring;
+  new nc: bitstring;
+  let staticCt = aenc(Spub, staticSs) in
+  let ch = (staticCt, nc) in
+  out(net, ch);
+  let transcript = TH(ch) in
+  let master = authMaster(staticSs, transcript) in
+  in(net, sfin: bitstring);
+  if sfin = macf(master, serverTag) then
+  event ClientAccept(Spub, transcript);
+  event AuthDone.
+
+let serverA(lsk: skey) =
+  in(net, ch: bitstring);
+  let (staticCt: bitstring, nc: bitstring) = ch in
+  let staticSs = adec(staticCt, lsk) in
+  let transcript = TH(ch) in
+  let master = authMaster(staticSs, transcript) in
+  event ServerRunning(pk(lsk), transcript);
+  out(net, macf(master, serverTag)).
+
+process
+  new lsk: skey;
+  let Spub = pk(lsk) in
+  out(net, Spub);
+  ( (! clientA(Spub)) | (! serverA(lsk)) )

--- a/docs/formal/chkem_fs.pv
+++ b/docs/formal/chkem_fs.pv
@@ -1,0 +1,34 @@
+(*
+  CH-KEM forward secrecy (symbolic). Load: -lib prelude.
+
+  An honest session derives the master from a fresh ephemeral leg secret and a static
+  leg encapsulated to the server's long-term key. In phase 1 the long-term key leaks,
+  so the attacker can recover the static-leg secret. Forward secrecy: the session key
+  and the data under it stay secret because the fresh ephemeral leg secret is never
+  exposed. (The ephemeral secret is an honest value, not an attacker-injectable
+  ciphertext; preventing active ephemeral-leg substitution is the authenticated
+  handshake's job - chkem_auth.pv.)
+*)
+
+free secretMsg: bitstring [private].
+
+query attacker(secretMsg).
+
+event Done.
+query event(Done).
+
+let session(Spub: pkey) =
+  new ephSs: bitstring;
+  new staticSs: bitstring;
+  new tr: bitstring;
+  let staticCt = aenc(Spub, staticSs) in
+  out(net, (staticCt, tr));
+  let master = deriveMaster(ephSs, staticSs, tr) in
+  event Done;
+  out(net, senc(secretMsg, kdfTraffic(master))).
+
+process
+  new lsk: skey;
+  let Spub = pk(lsk) in
+  out(net, Spub);
+  ( (! session(Spub)) | phase 1; out(net, lsk) )

--- a/docs/formal/chkem_hybrid.pv
+++ b/docs/formal/chkem_hybrid.pv
@@ -1,0 +1,47 @@
+(*
+  CH-KEM hybrid combiner - "secure if EITHER leg holds" (symbolic). Load: -lib prelude.
+
+  The ephemeral exchange has two KEM legs (X25519 and ML-KEM). Each leg's shared
+  secret is honestly generated. Each variant hands the attacker ONE leg's secret
+  (and the public transcript) and shows the master secret, hence the protected data,
+  stays secret via the other leg. This is the combiner-level hybrid guarantee:
+  knowing one input does not reveal the derived key. The legs' secrets are themselves
+  shown unrecoverable in chkem_secrecy.pv; together they give the hybrid property.
+
+  (Modeling the legs' KEM secrets as fresh honest values, not attacker-encapsulated
+  ciphertexts, deliberately excludes active leg-substitution MitM, which the
+  authenticated handshake - chkem_auth.pv - is what prevents.)
+*)
+
+free secretMsgA: bitstring [private].   (* protected when leg A is known to the attacker *)
+free secretMsgB: bitstring [private].   (* protected when leg B is known to the attacker *)
+
+query attacker(secretMsgA).
+query attacker(secretMsgB).
+
+event DoneH.
+query event(DoneH).
+
+(* Leg A's secret leaked; secrecy must hold via leg B. *)
+let leakA =
+  new ssA: bitstring;
+  new ssB: bitstring;
+  new tr: bitstring;
+  out(net, ssA);
+  out(net, tr);
+  let master = deriveMaster(ssA, ssB, tr) in
+  event DoneH;
+  out(net, senc(secretMsgA, kdfTraffic(master))).
+
+(* Leg B's secret leaked; secrecy must hold via leg A. *)
+let leakB =
+  new ssA: bitstring;
+  new ssB: bitstring;
+  new tr: bitstring;
+  out(net, ssB);
+  out(net, tr);
+  let master = deriveMaster(ssA, ssB, tr) in
+  out(net, senc(secretMsgB, kdfTraffic(master))).
+
+process
+  ( (! leakA) | (! leakB) )

--- a/docs/formal/chkem_secrecy.pv
+++ b/docs/formal/chkem_secrecy.pv
@@ -1,0 +1,46 @@
+(*
+  CH-KEM handshake - session-key secrecy (symbolic, Dolev-Yao). Load: -lib prelude.
+
+  The client encapsulates the ephemeral CH-KEM leg and a static leg to the pinned
+  server key, derives the master secret, and protects application data under the
+  traffic key. Proves the attacker cannot learn that data, and that an honest
+  session actually completes (non-vacuity).
+*)
+
+free secretMsg: bitstring [private].
+
+(* Session-key secrecy. *)
+query attacker(secretMsg).
+
+(* Reachability: an honest run completes (so secrecy is not vacuous). *)
+event Done.
+query event(Done).
+
+let client(Spub: pkey) =
+  new esk: skey;
+  new staticSs: bitstring;
+  new nc: bitstring;
+  let epk = pk(esk) in
+  let staticCt = aenc(Spub, staticSs) in
+  let ch = (epk, staticCt, nc) in
+  out(net, ch);
+  in(net, sh: bitstring);
+  let (ct: bitstring, ns: bitstring) = sh in
+  let ephSs = adec(ct, esk) in
+  let master = deriveMaster(ephSs, staticSs, TH((ch, sh))) in
+  event Done;
+  out(net, senc(secretMsg, kdfTraffic(master))).
+
+let server(lsk: skey) =
+  in(net, ch: bitstring);
+  let (epk: pkey, staticCt: bitstring, nc: bitstring) = ch in
+  new ephSs: bitstring;
+  new ns: bitstring;
+  let ct = aenc(epk, ephSs) in
+  out(net, (ct, ns)).
+
+process
+  new lsk: skey;
+  let Spub = pk(lsk) in
+  out(net, Spub);
+  ( (! client(Spub)) | (! server(lsk)) )

--- a/docs/formal/negative/auth_broken.pv
+++ b/docs/formal/negative/auth_broken.pv
@@ -1,0 +1,23 @@
+(* NEGATIVE: server "Finished" keyed off the public transcript, not the static-key
+   secret. Server authentication MUST fail (attacker forges it). Load: -lib prelude. *)
+event ServerRunning(pkey, bitstring).
+event ClientAccept(pkey, bitstring).
+query sp: pkey, t: bitstring;
+  inj-event(ClientAccept(sp, t)) ==> inj-event(ServerRunning(sp, t)).
+let clientA(Spub: pkey) =
+  new staticSs: bitstring; new nc: bitstring;
+  let ch = (aenc(Spub, staticSs), nc) in
+  out(net, ch);
+  let transcript = TH(ch) in
+  let master = authMaster(TH(ch), TH(ch)) in     (* BROKEN: no static secret *)
+  in(net, sfin: bitstring);
+  if sfin = macf(master, serverTag) then
+  event ClientAccept(Spub, transcript).
+let serverA(lsk: skey) =
+  in(net, ch: bitstring);
+  let (sc: bitstring, nc: bitstring) = ch in
+  let transcript = TH(ch) in
+  let master = authMaster(TH(ch), TH(ch)) in
+  event ServerRunning(pk(lsk), transcript);
+  out(net, macf(master, serverTag)).
+process new lsk: skey; out(net, pk(lsk)); ( (! clientA(pk(lsk))) | (! serverA(lsk)) )

--- a/docs/formal/negative/fs_broken.pv
+++ b/docs/formal/negative/fs_broken.pv
@@ -1,0 +1,12 @@
+(* NEGATIVE: master ignores the ephemeral secret. After the long-term key leaks,
+   forward secrecy MUST fail. Load: -lib prelude. *)
+free secretMsg: bitstring [private].
+query attacker(secretMsg).
+let session(Spub: pkey) =
+  new ephSs: bitstring; new staticSs: bitstring; new tr: bitstring;
+  let staticCt = aenc(Spub, staticSs) in
+  out(net, (staticCt, tr));
+  let master = authMaster(staticSs, tr) in       (* BROKEN: no ephemeral input *)
+  out(net, senc(secretMsg, kdfTraffic(master))).
+process new lsk: skey; let Spub = pk(lsk) in out(net, Spub);
+  ( (! session(Spub)) | phase 1; out(net, lsk) )

--- a/docs/formal/negative/hybrid_broken.pv
+++ b/docs/formal/negative/hybrid_broken.pv
@@ -1,0 +1,10 @@
+(* NEGATIVE: combiner ignores leg B. With leg A leaked, secrecy MUST fail.
+   Load: -lib prelude. *)
+free secretMsgA: bitstring [private].
+query attacker(secretMsgA).
+let leakA =
+  new ssA: bitstring; new ssB: bitstring; new tr: bitstring;
+  out(net, ssA); out(net, tr);
+  let master = kdfTraffic(ssA) in                (* BROKEN: ignores ssB *)
+  out(net, senc(secretMsgA, master)).
+process ( ! leakA )

--- a/docs/formal/negative/secrecy_broken.pv
+++ b/docs/formal/negative/secrecy_broken.pv
@@ -1,0 +1,17 @@
+(* NEGATIVE: combiner forgets the KEM secrets and keys traffic off the public
+   transcript only. Secrecy MUST fail (attacker recovers the key). Load: -lib prelude. *)
+free secretMsg: bitstring [private].
+query attacker(secretMsg).
+let client(Spub: pkey) =
+  new esk: skey; new staticSs: bitstring; new nc: bitstring;
+  let ch = (pk(esk), aenc(Spub, staticSs), nc) in
+  out(net, ch);
+  in(net, sh: bitstring);
+  let master = kdfTraffic(TH((ch, sh))) in       (* BROKEN: no secret input *)
+  out(net, senc(secretMsg, master)).
+let server =
+  in(net, ch: bitstring);
+  let (epk: pkey, sc: bitstring, nc: bitstring) = ch in
+  new e: bitstring; new ns: bitstring;
+  out(net, (aenc(epk, e), ns)).
+process new lsk: skey; out(net, pk(lsk)); ( (! client(pk(lsk))) | (! server) )

--- a/docs/formal/prelude.pvl
+++ b/docs/formal/prelude.pvl
@@ -1,0 +1,23 @@
+(* Shared declarations for the CH-KEM ProVerif models. Load with: proverif -lib prelude *)
+type skey.
+type pkey.
+
+(* IND-CCA KEM as public-key encryption of a fresh shared secret. *)
+fun pk(skey): pkey.
+fun aenc(pkey, bitstring): bitstring.
+reduc forall sk: skey, m: bitstring; adec(aenc(pk(sk), m), sk) = m.
+
+(* One-way KDF / MAC, collision-resistant in the symbolic model. *)
+fun TH(bitstring): bitstring.                                 (* transcript hash *)
+fun deriveMaster(bitstring, bitstring, bitstring): bitstring.  (* eph_ss, static_ss, transcript *)
+fun kdfTraffic(bitstring): bitstring.
+fun macf(bitstring, bitstring): bitstring.
+
+(* symmetric encryption, only to express key secrecy *)
+fun senc(bitstring, bitstring): bitstring.
+reduc forall m: bitstring, k: bitstring; sdec(senc(m, k), k) = m.
+
+const clientTag: bitstring.
+const serverTag: bitstring.
+free net: channel.
+fun authMaster(bitstring, bitstring): bitstring.              (* static_ss, transcript -> master *)

--- a/docs/formal/proverif.Dockerfile
+++ b/docs/formal/proverif.Dockerfile
@@ -1,0 +1,9 @@
+# ProVerif runner for the Quantum-Go formal models. Built on opam's official OCaml
+# image; "opam install" fetches and builds ProVerif. The same image runs locally
+# (docs/formal/verify.sh) and in CI (.github/workflows/formal.yml).
+#
+# The ProVerif version is pinned for reproducible proofs. For a fully reproducible
+# build, also pin the base by digest (FROM ocaml/opam:debian-12@sha256:...).
+FROM ocaml/opam:debian-12
+RUN opam install -y proverif.2.05
+ENTRYPOINT ["opam", "exec", "--", "proverif"]

--- a/docs/formal/verify.sh
+++ b/docs/formal/verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify the Quantum-Go ProVerif models: every positive model must PROVE all its
+# queries, every negative (planted-flaw) model must FAIL its security query. Writes
+# the proof log to RESULTS.txt. The same script runs locally and in CI.
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+IMG="${PROVERIF_IMAGE:-qgo-proverif}"
+RESULTS="$DIR/RESULTS.txt"
+run() { docker run --rm -v "$DIR:/work" -w /work "$IMG" -lib prelude "$1" 2>&1; }
+
+ver=$(docker run --rm "$IMG" -help 2>&1 | head -1)
+# No commit/date in the header: RESULTS.txt then changes only when the PROOFS change,
+# so CI can assert the committed log is up to date. Git history provides traceability.
+{
+  echo "Quantum-Go formal verification results"
+  echo "Tool: $ver"
+  echo "Protocol version verified: 5.0"
+  echo
+} > "$RESULTS"
+
+fail=0
+echo "== positive models (must prove) =="
+for f in "$DIR"/*.pv; do
+  name=$(basename "$f"); out=$(run "$name")
+  { echo "=== $name ==="; echo "$out" | grep -E "^RESULT"; echo; } >> "$RESULTS"
+  res=$(echo "$out" | grep -E "^RESULT")
+  bad=$(echo "$res" | grep -vE "is true|not event\([A-Za-z0-9]+\) is false")
+  if [ -z "$res" ] || echo "$out" | grep -q "cannot be proved" || [ -n "$bad" ]; then
+    echo "  FAIL  $name"; [ -n "$bad" ] && echo "$bad" | sed 's/^/        /'; fail=1
+  else echo "  ok    $name"; fi
+done
+
+echo "== negative models (must fail) =="
+for f in "$DIR"/negative/*.pv; do
+  name=$(basename "$f"); out=$(run "negative/$name")
+  { echo "=== negative/$name ==="; echo "$out" | grep -E "^RESULT"; echo; } >> "$RESULTS"
+  res=$(echo "$out" | grep -E "^RESULT")
+  if [ -n "$res" ] && echo "$res" | grep -q "is false"; then
+    echo "  ok    $name (flaw detected)"
+  else echo "  FAIL  $name (flaw NOT detected)"; fail=1; fi
+done
+
+[ "$fail" = 0 ] && echo "ALL MODELS VERIFIED" || echo "VERIFICATION FAILED"
+exit $fail


### PR DESCRIPTION
Assurance tier #2: formal verification. Symbolic (Dolev-Yao) ProVerif proofs of the handshake's core security, machine-checked and reproducible.

## What is proven (committed log: `docs/formal/RESULTS.txt`)
| Property | Model | Result |
|---|---|---|
| Session-key secrecy | `chkem_secrecy.pv` | proven |
| **Hybrid: secret if EITHER ML-KEM or X25519 leg holds** | `chkem_hybrid.pv` | proven |
| Forward secrecy (after long-term-key leak) | `chkem_fs.pv` | proven |
| Injective server authentication + transcript agreement | `chkem_auth.pv` | proven |

Active attacker: controls the whole network (intercept/modify/inject/replay), unbounded sessions, and is handed compromised secrets in the hybrid/FS models. (ProVerif earned its keep mid-development - it *found* the active leg-substitution MitM on a naive model and failed the query, forcing precise scoping.)

## Trustworthiness (the parts an auditor probes)
- **Non-vacuity, enforced:** every model has a reachability query (the honest run completes), and a `negative/` planted-flaw twin per property that **must fail** its query - the suite demonstrably detects a flaw, so the proofs aren't trivially true.
- **Reproducible:** pinned ProVerif 2.05 image; one `verify.sh` is the single source of truth for local + CI + third parties; committed `RESULTS.txt` lets an auditor see results without running anything.
- **Honest scope:** symbolic (perfect-crypto) verification of the protocol composition - catches MitM/replay/downgrade/auth-bypass/mis-binding, not computational/side-channel breaks. The README maps each model primitive to its Go function and notes the conformance vectors pin the byte-level behavior; it complements the computational IND-CCA argument.
- **Anti-rot:** README lists the code files the models track and the sync obligation.

## CI
`.github/workflows/formal.yml` is **path-filtered to `docs/formal/**`** so it never gates ordinary commits; it builds the pinned image (with layer cache), runs `verify.sh` (positives prove, negatives fail), and asserts `RESULTS.txt` is up to date.

Docs-only (no Go change). Coverage map (PSK, downgrade, rekey, per-suite, computational) in the README as drop-in follow-ups.